### PR TITLE
Fix: home

### DIFF
--- a/Loopy-fe/src/App.tsx
+++ b/Loopy-fe/src/App.tsx
@@ -17,7 +17,9 @@ import ErrorPage from './pages/ErrorPage.tsx';
 import SearchPage from './pages/User/Search/index.tsx';
 import AlarmPage from './pages/User/Alarm/index.tsx';
 import BookMarkPage from './pages/User/BookMark/index.tsx';
-import OnBoard from "./pages/User/OnBoard/index.tsx";
+import OnBoard from './pages/User/OnBoard/index.tsx';
+import ChallengePage from './pages/User/Challenge/index.tsx';
+import LevelDetailPage from './pages/User/LevelDetail/index.tsx';
 
 const publicRoutes = createBrowserRouter([
   {
@@ -34,11 +36,11 @@ const publicRoutes = createBrowserRouter([
         element: <SigninPage />,
       },
       {
-        path: "onboard",
+        path: 'onboard',
         element: <OnBoard />,
       },
       {
-        path: "home",
+        path: 'home',
         element: <HomePage />,
       },
       {
@@ -64,6 +66,14 @@ const publicRoutes = createBrowserRouter([
       {
         path: 'bookmark',
         element: <BookMarkPage />,
+      },
+      {
+        path: 'challenge',
+        element: <ChallengePage />,
+      },
+      {
+        path: 'level',
+        element: <LevelDetailPage />,
       },
     ],
   },

--- a/Loopy-fe/src/assets/images/Down.svg
+++ b/Loopy-fe/src/assets/images/Down.svg
@@ -1,0 +1,3 @@
+<svg width="10" height="6" viewBox="0 0 10 6" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 1L5 5L9 1" stroke="#252525" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/Loopy-fe/src/pages/User/Challenge/index.tsx
+++ b/Loopy-fe/src/pages/User/Challenge/index.tsx
@@ -1,0 +1,14 @@
+import { useNavigate } from 'react-router-dom';
+import CommonHeader from '../../../components/header/CommonHeader';
+
+const ChallengePage = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div>
+      <CommonHeader title="챌린지" onBack={() => navigate(-1)} />
+    </div>
+  );
+};
+
+export default ChallengePage;

--- a/Loopy-fe/src/pages/User/Home/components/ChallangeCard.tsx
+++ b/Loopy-fe/src/pages/User/Home/components/ChallangeCard.tsx
@@ -1,0 +1,24 @@
+interface ChallengeCardProps {
+  challengeName: string;
+  challengeImage: string;
+}
+
+const ChallengeCard = ({
+  challengeName,
+  challengeImage,
+}: ChallengeCardProps) => {
+  return (
+    <div className="w-[10.5rem] h-[10.5rem] min-w-[10.5rem] flex-shrink-0 bg-[#F0F1FE] rounded-lg flex flex-col items-center justify-center">
+      <img
+        src={challengeImage}
+        alt={challengeName}
+        className="w-[8.5rem] h-[5.25rem] object-cover mb-2 rounded-md"
+      />
+      <div className="text-[1rem] font-semibold self-start px-4 whitespace-pre-wrap">
+        {challengeName}
+      </div>
+    </div>
+  );
+};
+
+export default ChallengeCard;

--- a/Loopy-fe/src/pages/User/Home/components/ChallengeCarousel.tsx
+++ b/Loopy-fe/src/pages/User/Home/components/ChallengeCarousel.tsx
@@ -1,0 +1,39 @@
+import { useRef } from 'react';
+import ChallengeCard from './ChallangeCard';
+import RoundButton from './RoundButton';
+import { challengeCardList } from '../mock/mockData';
+
+const ChallengeCarousel = () => {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const handleScroll = () => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollBy({ left: 200, behavior: 'smooth' });
+    }
+  };
+
+  return (
+    <div className="relative w-full">
+      <div
+        ref={scrollRef}
+        className="flex overflow-x-auto space-x-2 no-scrollbar scroll-smooth px-0 pb-2"
+      >
+        {challengeCardList.map((challenge, index) => (
+          <ChallengeCard
+            key={index}
+            challengeName={challenge.challengeName}
+            challengeImage={challenge.challengeImage}
+          />
+        ))}
+      </div>
+
+      <div className="absolute right-2 top-1/2 -translate-y-1/2 z-10">
+        <div onClick={handleScroll}>
+          <RoundButton />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ChallengeCarousel;

--- a/Loopy-fe/src/pages/User/Home/components/DetailButton.tsx
+++ b/Loopy-fe/src/pages/User/Home/components/DetailButton.tsx
@@ -1,0 +1,19 @@
+interface DetailButtonProps {
+  onClick?: () => void;
+  textColor?: string;
+  label?: string;
+}
+
+const DetailButton = ({ onClick, textColor, label }: DetailButtonProps) => {
+  return (
+    <button
+      className={`flex items-center gap-1 text-[0.875rem] font-normal ${textColor}`}
+      onClick={onClick}
+    >
+      <span>{label}</span>
+      <span>→</span>
+    </button>
+  );
+};
+
+export default DetailButton;

--- a/Loopy-fe/src/pages/User/Home/components/MyStamp.tsx
+++ b/Loopy-fe/src/pages/User/Home/components/MyStamp.tsx
@@ -24,7 +24,7 @@ const MyStamp: React.FC<MyStampProps> = ({
       {/* 스탬프 영역 */}
       <div className="absolute w-[16.375rem] h-[5rem] rounded-br-[6.25rem] top-0 right-0 bg-[#E3F389] px-4 py-3 flex flex-col items-end justify-center">
         {/* 스탬프 개수 + 화살표 */}
-        <div className="absolute top-[0.938rem] left-[6.25rem] flex items-center gap-10 text-[1rem] font-semibold text-black">
+        <div className="absolute top-[0.938rem] left-[6.25rem] flex items-center gap-10 text-base font-semibold text-black">
           <span>스탬프 {stampCount}개</span>
           <span className="text-lg cursor-pointer">→</span>
         </div>

--- a/Loopy-fe/src/pages/User/Home/components/NoChallangeCard.tsx
+++ b/Loopy-fe/src/pages/User/Home/components/NoChallangeCard.tsx
@@ -1,0 +1,19 @@
+const NoChallengeCard = () => {
+  return (
+    <div className="bg-[#F0F1FE] rounded-lg p-6 flex flex-col justify-center">
+      <span className="text-[1rem] font-bold">
+        아직 참여 중인 챌린지가 없어요!
+      </span>
+      <span className="text-[0.875rem] font-normal">
+        루피와 작은 챌린지부터 시작해볼까요?
+      </span>
+      <div className="rounded-sm">
+        <button className="bg-transparent text-[#6970F3] border border-[#6970F3] rounded-lg w-full h-[2.5rem] text-[0.875rem] font-semibold mt-3">
+          참여 가능한 챌린지 보러가기
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default NoChallengeCard;

--- a/Loopy-fe/src/pages/User/Home/components/NoLevelCard.tsx
+++ b/Loopy-fe/src/pages/User/Home/components/NoLevelCard.tsx
@@ -1,0 +1,14 @@
+const NoLevelCard = () => {
+  return (
+    <div className="w-[10.875rem] h-[9.75rem] border border-dashed border-white rounded-lg flex flex-col items-center justify-center">
+      <div className="text-[1rem] font-bold text-white">아직 레벨이 없어요</div>
+      <div className="text-[0.875rem] text-[#DFDFDF] mt-1 font-normal text-center">
+        카페 루틴을 채워가면
+        <br />
+        루피 레벨이 생겨요!
+      </div>
+    </div>
+  );
+};
+
+export default NoLevelCard;

--- a/Loopy-fe/src/pages/User/Home/components/ProfileCard.tsx
+++ b/Loopy-fe/src/pages/User/Home/components/ProfileCard.tsx
@@ -1,0 +1,93 @@
+import DetailButton from './DetailButton';
+import { useNavigate } from 'react-router-dom';
+
+interface ProfileCardProps {
+  username: string;
+  level: string;
+  imageUrl?: string;
+  receivedStamps: number;
+  ongoingChallenges: number;
+  totalStamps: number;
+  points: number;
+}
+
+const ProfileCard = ({
+  username,
+  level,
+  imageUrl,
+  receivedStamps,
+  ongoingChallenges,
+  totalStamps,
+  points,
+}: ProfileCardProps) => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="text-white">
+      {/* 이름 + 레벨 + 레벨 전체보기 */}
+      <div className="text-[1.5rem] font-bold">{username}님은</div>
+      <div className="flex items-center justify-between mt-1">
+        <div className="text-[1.5rem] font-bold text-[#E3F389]">{level}</div>
+        <DetailButton
+          onClick={() => navigate('/level')}
+          textColor="text-white"
+          label="레벨 전체보기"
+        />
+      </div>
+
+      {/* 이미지 + 우측 정보 묶기 */}
+      <div className="flex mt-4">
+        {/* 프로필 이미지 */}
+        <div className="w-[10.875rem] h-[9.75rem] overflow-hidden  flex-shrink-0">
+          {imageUrl ? (
+            <img
+              src={imageUrl}
+              alt="profile"
+              className="w-full h-full object-cover"
+            />
+          ) : (
+            <div className="w-full h-full bg-[#ddd] flex items-center justify-center text-black">
+              이미지
+            </div>
+          )}
+        </div>
+
+        {/*현황 + 카드 */}
+        <div className="ml-4 flex flex-col justify-between">
+          {/* 이번달 현황 */}
+          <div className="text-[1rem] font-semibold">
+            <div>이번달 현황</div>
+            <div className="flex justify-between mt-1 text-[0.875rem] text-[#E3F389] pr-4">
+              <div className="font-normal">받은 스탬프</div>
+              <div className="font-semibold">{receivedStamps}개</div>
+            </div>
+            <div className="flex justify-between text-[0.875rem]  text-[#E3F389] pr-4">
+              <div className="font-normal">진행 중인 챌린지</div>
+              <div className="font-semibold">{ongoingChallenges}개</div>
+            </div>
+          </div>
+
+          {/* 하단 카드 */}
+          <div className="flex gap-2 mt-4">
+            <div className="w-[4.5rem] h-[4.5rem] bg-white/30 rounded-[4px] p-2 text-center">
+              <div className="text-[0.875rem] font-semibold mt-0.5">
+                총 스탬프
+              </div>
+              <div className="text-[1.125rem] font-bold text-[#E3F389] mt-1">
+                {totalStamps}개
+              </div>
+            </div>
+            <div className="w-[4.5rem] h-[4.5rem] bg-white/30 rounded-[4px] p-2 text-center">
+              <div className="text-[0.875rem] font-semibold mt-0.5">포인트</div>
+              <div className="text-[1.125rem] font-bold text-[#E3F389] mt-1">
+                {points}p
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ProfileCard;

--- a/Loopy-fe/src/pages/User/Home/components/RoundButton.tsx
+++ b/Loopy-fe/src/pages/User/Home/components/RoundButton.tsx
@@ -1,0 +1,9 @@
+const RoundButton = () => {
+  return (
+    <button className="rounded-full bg-white text-black p-2 w-[40px] h-[40px] shadow-sm">
+      <span>→</span>
+    </button>
+  );
+};
+
+export default RoundButton;

--- a/Loopy-fe/src/pages/User/Home/components/StampSort.tsx
+++ b/Loopy-fe/src/pages/User/Home/components/StampSort.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import Down from '../../../../assets/images/Down.svg?react';
+
+interface StampSortProps {
+  value: string;
+  onChange: (sortType: string) => void;
+}
+
+const StampSort = ({ value, onChange }: StampSortProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const options = [
+    { label: '적립 많은 순', value: 'most' },
+    { label: '기한 짧은 순', value: 'due' },
+  ];
+
+  const handleSelect = (val: string) => {
+    onChange(val);
+    setIsOpen(false);
+  };
+
+  return (
+    <div className="relative text-left text-sm">
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex justify-between w-[6.875rem] h-[1.75rem] px-3 py-[6px] bg-[#F3F3F3] rounded-sm text-[0.875rem] items-center"
+      >
+        {options.find((opt) => opt.value === value)?.label || '정렬'}
+        <Down />
+      </button>
+
+      {isOpen && (
+        <ul className="absolute z-10 mt-2 w-[6.875rem] bg-white border border-gray-200 rounded-md shadow-sm">
+          {options.map((option) => (
+            <li
+              key={option.value}
+              className={`px-4 py-2 hover:bg-gray-100 ${
+                value === option.value ? 'font-semibold text-[#6970F3]' : ''
+              }`}
+              onClick={() => handleSelect(option.value)}
+            >
+              {option.label}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default StampSort;

--- a/Loopy-fe/src/pages/User/Home/index.tsx
+++ b/Loopy-fe/src/pages/User/Home/index.tsx
@@ -1,68 +1,57 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import CommonBottomBar from '../../../components/bottomBar/CommonBottomBar';
 import MyStamp from './components/MyStamp';
+import ProfileCard from './components/ProfileCard';
 import TopBar from './components/TopBar';
+import StampSort from './components/StampSort';
+import { stampList, profileCardData } from './mock/mockData';
+import DetailButton from './components/DetailButton';
+import ChallengeCarousel from './components/ChallengeCarousel';
 
 const HomePage = () => {
+  const [sortType, setSortType] = useState('most');
+  const navigate = useNavigate();
+  const sortedList = [...stampList].sort((a, b) => {
+    if (sortType === 'most') return b.stampCount - a.stampCount;
+    if (sortType === 'due')
+      return new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime();
+    return 0;
+  });
+
   return (
     <div className="relative min-h-screen">
       <div className="absolute inset-0 -mx-[1.5rem] bg-gradient-to-b from-[#6970F3] to-[#3D418D] z-0" />
-
       <div className="relative z-10">
         <TopBar />
-        <CommonBottomBar
-          active="home"
-          onChange={(tab) => {
-            console.log(tab);
-          }}
-        />
-
-        <div className="bg-white rounded-t-xl pt-10 -mx-[1.5rem]">
-          <div className="px-[1.5rem] font-bold text-[1.25rem]">내 스탬프</div>
-          <div className="px-[1.5rem] text-[0.875rem] text-gray-500 mt-2">
+        <CommonBottomBar active="home" onChange={(tab) => console.log(tab)} />
+        <ProfileCard {...profileCardData} />
+        <div className="bg-white rounded-t-xl mt-8 pt-8 -mx-[1.5rem] px-[1.5rem]">
+          <div className=" font-bold text-[1.125rem] flex justify-between items-center mb-4">
+            <span>루피와 진행 중인 챌린지, 뤂챌린지</span>
+            <DetailButton
+              onClick={() => navigate('/challenge')}
+              textColor="text-[#7F7F7F]"
+              label="전체보기"
+            />
+          </div>
+          <ChallengeCarousel />
+          <div className="flex justify-between items-center mt-6">
+            <div className="font-bold text-[1.125rem] flex items-center gap-2">
+              <span>내 스탬프지</span>
+              <span className="text-[#6970F3] text-[1.125rem]">
+                {stampList.length}개
+              </span>
+            </div>
+            <StampSort value={sortType} onChange={setSortType} />
+          </div>
+          <div className=" text-[0.875rem] text-gray-500 mt-2">
             1달 내 재방문이 없으면 포인트로 자동 환전되어요
           </div>
-          <div className=" px-[1.5rem] mt-4 pb-[5rem]">
-            {/*목데이터*/}
-            <MyStamp
-              imageUrl="https://images.unsplash.com/photo-1529070538774-1843cb3265df?auto=format&fit=crop&w=400&q=80"
-              cafeName="카페 위니"
-              address="서울 서대문구 이화여대길 52"
-              stampCount={5}
-              stampMax={10}
-              dueDate="8/15"
-            />
-            <MyStamp
-              imageUrl="https://images.unsplash.com/photo-1529070538774-1843cb3265df?auto=format&fit=crop&w=400&q=80"
-              cafeName="카페 위니"
-              address="서울 서대문구 이화여대길 52"
-              stampCount={8}
-              stampMax={10}
-              dueDate="8/15"
-            />
-            <MyStamp
-              imageUrl="https://images.unsplash.com/photo-1529070538774-1843cb3265df?auto=format&fit=crop&w=400&q=80"
-              cafeName="카페 위니"
-              address="서울 서대문구 이화여대길 52"
-              stampCount={1}
-              stampMax={10}
-              dueDate="8/15"
-            />
-            <MyStamp
-              imageUrl="https://images.unsplash.com/photo-1529070538774-1843cb3265df?auto=format&fit=crop&w=400&q=80"
-              cafeName="카페 위니"
-              address="서울 서대문구 이화여대길 52"
-              stampCount={1}
-              stampMax={10}
-              dueDate="8/15"
-            />
-            <MyStamp
-              imageUrl="https://images.unsplash.com/photo-1529070538774-1843cb3265df?auto=format&fit=crop&w=400&q=80"
-              cafeName="카페 위니"
-              address="서울 서대문구 이화여대길 52"
-              stampCount={1}
-              stampMax={10}
-              dueDate="8/15"
-            />
+          <div className=" mt-4 pb-[5rem]">
+            {sortedList.map((stamp, idx) => (
+              <MyStamp key={idx} {...stamp} />
+            ))}
           </div>
         </div>
       </div>

--- a/Loopy-fe/src/pages/User/Home/mock/mockData.ts
+++ b/Loopy-fe/src/pages/User/Home/mock/mockData.ts
@@ -1,0 +1,101 @@
+export interface StampItem {
+  imageUrl: string;
+  cafeName: string;
+  address: string;
+  stampCount: number;
+  stampMax: number;
+  dueDate: string;
+}
+
+export interface ProfileCardData {
+  username: string;
+  level: string;
+  imageUrl?: string;
+  receivedStamps: number;
+  ongoingChallenges: number;
+  totalStamps: number;
+  points: number;
+}
+
+export interface ChallengeCardData {
+  challengeName: string;
+  challengeImage: string;
+}
+
+export const stampList: StampItem[] = [
+  {
+    imageUrl:
+      'https://images.unsplash.com/photo-1529070538774-1843cb3265df?auto=format&fit=crop&w=400&q=80',
+    cafeName: '카페 위니',
+    address: '서울 서대문구 이화여대길 52',
+    stampCount: 5,
+    stampMax: 10,
+    dueDate: '10/7',
+  },
+  {
+    imageUrl:
+      'https://images.unsplash.com/photo-1529070538774-1843cb3265df?auto=format&fit=crop&w=400&q=80',
+    cafeName: '카페 위니',
+    address: '서울 서대문구 이화여대길 52',
+    stampCount: 2,
+    stampMax: 10,
+    dueDate: '11/15',
+  },
+  {
+    imageUrl:
+      'https://images.unsplash.com/photo-1529070538774-1843cb3265df?auto=format&fit=crop&w=400&q=80',
+    cafeName: '카페 위니',
+    address: '서울 서대문구 이화여대길 52',
+    stampCount: 4,
+    stampMax: 10,
+    dueDate: '7/30',
+  },
+  {
+    imageUrl:
+      'https://images.unsplash.com/photo-1529070538774-1843cb3265df?auto=format&fit=crop&w=400&q=80',
+    cafeName: '카페 위니',
+    address: '서울 서대문구 이화여대길 52',
+    stampCount: 8,
+    stampMax: 10,
+    dueDate: '8/15',
+  },
+];
+
+export const profileCardData: ProfileCardData = {
+  username: '루피25',
+  level: '호기심 많은 탐색가',
+  imageUrl:
+    'https://images.unsplash.com/photo-1529070538774-1843cb3265df?auto=format&fit=crop&w=400&q=80',
+  receivedStamps: 5,
+  ongoingChallenges: 2,
+  totalStamps: 10,
+  points: 100,
+};
+
+export const challengeCardList: ChallengeCardData[] = [
+  {
+    challengeName: '지구를 지켜요!\n텀블러 챌린지',
+    challengeImage:
+      'https://images.unsplash.com/photo-1529070538774-1843cb3265df?auto=format&fit=crop&w=400&q=80',
+  },
+  {
+    challengeName: '지구를 지켜요!\n텀블러 챌린지',
+    challengeImage:
+      'https://images.unsplash.com/photo-1529070538774-1843cb3265df?auto=format&fit=crop&w=400&q=80',
+  },
+  {
+    challengeName: '지구를 지켜요!\n텀블러 챌린지',
+    challengeImage:
+      'https://images.unsplash.com/photo-1529070538774-1843cb3265df?auto=format&fit=crop&w=400&q=80',
+  },
+  {
+    challengeName: '지구를 지켜요!\n텀블러 챌린지',
+    challengeImage:
+      'https://images.unsplash.com/photo-1529070538774-1843cb3265df?auto=format&fit=crop&w=400&q=80',
+  },
+  {
+    challengeName: '지구를 지켜요!\n텀블러 챌린지',
+    challengeImage:
+      'https://images.unsplash.com/photo-1529070538774-1843cb3265df?auto=format&fit=crop&w=400&q=80',
+  },
+];

--- a/Loopy-fe/src/pages/User/LevelDetail/index.tsx
+++ b/Loopy-fe/src/pages/User/LevelDetail/index.tsx
@@ -1,0 +1,14 @@
+import { useNavigate } from 'react-router-dom';
+import CommonHeader from '../../../components/header/CommonHeader';
+
+const LevelDetailPage = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div>
+      <CommonHeader title="루피 레벨 안내" onBack={() => navigate(-1)} />
+    </div>
+  );
+};
+
+export default LevelDetailPage;


### PR DESCRIPTION
## 📌 변경사항
- 홈 화면 상단의 프로필 부분 구현
- 뤂챌린지 캐러셀 구현
- 내 스탬지 정렬 방법 드롭다운 구현
- 홈화면에서 레벨 상세페이지, 챌린지 상세페이지 연결

## ✅ 작업 내용 체크리스트
- [X] 자잘한 UI 수정
- [X] 홈 화면 전체 구현
- [X] 레벨 없는 경우, 챌린지 없는 경우 컴포넌트로 구현

## 📷 스크린샷 or 영상 (선택)
![image](https://github.com/user-attachments/assets/cba99403-ecff-4f1c-bd0c-8b5a2b5ed2d0)
![image](https://github.com/user-attachments/assets/904cdee1-fa3a-419d-877e-efacaace2d27)
![image](https://github.com/user-attachments/assets/ffa4ffeb-0d73-47e7-8938-f97af7faae4b)
![image](https://github.com/user-attachments/assets/0996b2af-1d01-4a4c-b396-3cc91a2b405c)


## 🧪 테스트 방법 (선택)
> 어떻게 테스트했는지 설명해주세요.
