### PR TITLE
Feat: challenge list page

### DIFF
--- a/Loopy-fe/src/assets/images/BookmarkWhite.svg
+++ b/Loopy-fe/src/assets/images/BookmarkWhite.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="20" viewBox="0 0 16 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 5.8C1 4.11984 1 3.27976 1.32698 2.63803C1.6146 2.07354 2.07354 1.6146 2.63803 1.32698C3.27976 1 4.11984 1 5.8 1H10.2C11.8802 1 12.7202 1 13.362 1.32698C13.9265 1.6146 14.3854 2.07354 14.673 2.63803C15 3.27976 15 4.11984 15 5.8V19L8 15L1 19V5.8Z" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/Loopy-fe/src/pages/User/Challenge/components/AllChallengeList.tsx
+++ b/Loopy-fe/src/pages/User/Challenge/components/AllChallengeList.tsx
@@ -1,0 +1,20 @@
+import ChallengeCard from './ChallengeCard';
+import { challengeCardList } from '../mock/mockData';
+
+const AllChallengeList: React.FC = () => {
+  return (
+    <div className="flex flex-col gap-6">
+      {challengeCardList.length > 0 ? (
+        challengeCardList.map((challenge, index) => (
+          <ChallengeCard key={index} data={challenge} />
+        ))
+      ) : (
+        <div className="text-gray-500 text-sm text-center">
+          챌린지가 없습니다.
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AllChallengeList;

--- a/Loopy-fe/src/pages/User/Challenge/components/ChallengeCard.tsx
+++ b/Loopy-fe/src/pages/User/Challenge/components/ChallengeCard.tsx
@@ -1,0 +1,50 @@
+import type { ChallengeCardData } from '../mock/mockData';
+
+interface ChallengeCardProps {
+  data: ChallengeCardData;
+  hideParticipatingTag?: boolean;
+}
+
+const ChallengeCard: React.FC<ChallengeCardProps> = ({
+  data,
+  hideParticipatingTag,
+}) => {
+  const {
+    challengeMonth,
+    challengeName,
+    challengeStartDate,
+    challengeDoneDate,
+    challengeImage,
+    participating,
+  } = data;
+
+  return (
+    <div className="flex items-center -mx-[1rem]">
+      {/* 좌측 이미지 */}
+      <img
+        src={challengeImage}
+        alt={challengeName}
+        className="w-[4.5rem] h-[4.5rem] object-cover rounded-full mr-4"
+      />
+      {/* 중앙 텍스트 */}
+      <div className="flex-1">
+        <div className="text-xs font-normal text-[#6970F3] mb-1">
+          {challengeMonth ? `${challengeMonth}월의 이벤트` : '루피만의 챌린지!'}
+        </div>
+        <div className="text-base font-bold mb-1">{challengeName}</div>
+        <div className="text-sm font-normal text-[#7F7F7F]">
+          {challengeStartDate} ~ {challengeDoneDate}
+        </div>
+      </div>
+
+      {/* 우측 태그 */}
+      {!hideParticipatingTag && participating && (
+        <div className="w-[3.188rem] h-[1.25rem] ml-4 px-2 py-1 bg-[#F0F1FE] text-[#6970F3] rounded-sm text-xs font-[0.75rem] items-center">
+          참여 중
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ChallengeCard;

--- a/Loopy-fe/src/pages/User/Challenge/components/ChallengeTab.tsx
+++ b/Loopy-fe/src/pages/User/Challenge/components/ChallengeTab.tsx
@@ -1,0 +1,33 @@
+interface ChallengeTabProps {
+  activeTab: 'participating' | 'all';
+  onChangeTab: (tab: 'participating' | 'all') => void;
+}
+
+const ChallengeTab = ({ activeTab, onChangeTab }: ChallengeTabProps) => {
+  return (
+    <div className="w-[21.563rem] flex justify-between mt-4">
+      <button
+        onClick={() => onChangeTab('participating')}
+        className={`w-[10.75rem] pb-2 text-sm border-b ${
+          activeTab === 'participating'
+            ? 'text-[#6970F3] font-semibold border-[#6970F3]'
+            : 'text-[#A8A8A8] font-medium border-[#F3F3F3]'
+        }`}
+      >
+        참여 중인 챌린지
+      </button>
+      <button
+        onClick={() => onChangeTab('all')}
+        className={`w-[10.75rem] pb-2 text-sm border-b ${
+          activeTab === 'all'
+            ? 'text-[#6970F3] font-semibold border-[#6970F3]'
+            : 'text-[#A8A8A8] font-medium border-[#F3F3F3]'
+        }`}
+      >
+        전체 챌린지
+      </button>
+    </div>
+  );
+};
+
+export default ChallengeTab;

--- a/Loopy-fe/src/pages/User/Challenge/components/ParticipatingChallengeList.tsx
+++ b/Loopy-fe/src/pages/User/Challenge/components/ParticipatingChallengeList.tsx
@@ -1,0 +1,28 @@
+import ChallengeCard from './ChallengeCard';
+import { challengeCardList } from '../mock/mockData';
+
+const ParticipatingChallengeList: React.FC = () => {
+  const participatingChallenges = challengeCardList.filter(
+    (challenge) => challenge.participating,
+  );
+
+  return (
+    <div className="flex flex-col gap-6">
+      {participatingChallenges.length > 0 ? (
+        participatingChallenges.map((challenge, index) => (
+          <ChallengeCard
+            key={index}
+            data={challenge}
+            hideParticipatingTag={true}
+          />
+        ))
+      ) : (
+        <div className="text-gray-500 text-sm text-center">
+          참여 중인 챌린지가 없습니다.
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ParticipatingChallengeList;

--- a/Loopy-fe/src/pages/User/Challenge/index.tsx
+++ b/Loopy-fe/src/pages/User/Challenge/index.tsx
@@ -1,12 +1,29 @@
 import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
 import CommonHeader from '../../../components/header/CommonHeader';
+import ParticipatingChallengeList from './components/ParticipatingChallengeList';
+import AllChallengeList from './components/AllChallengeList';
+import ChallengeTab from './components/ChallengeTab';
 
 const ChallengePage = () => {
   const navigate = useNavigate();
+  const [activeTab, setActiveTab] = useState<'participating' | 'all'>(
+    'participating',
+  );
 
   return (
-    <div>
+    <div className="w-full min-h-screen bg-white">
       <CommonHeader title="챌린지" onBack={() => navigate(-1)} />
+      {/* 탭 메뉴 */}
+      <ChallengeTab activeTab={activeTab} onChangeTab={setActiveTab} />
+      {/* 탭 콘텐츠 */}
+      <div className="mt-4 px-4">
+        {activeTab === 'participating' ? (
+          <ParticipatingChallengeList />
+        ) : (
+          <AllChallengeList />
+        )}
+      </div>
     </div>
   );
 };

--- a/Loopy-fe/src/pages/User/Challenge/mock/mockData.ts
+++ b/Loopy-fe/src/pages/User/Challenge/mock/mockData.ts
@@ -1,0 +1,83 @@
+export interface ChallengeCardData {
+  challengeMonth?: number;
+  challengeName: string;
+  challengeStartDate: string;
+  challengeDoneDate: string;
+  challengeImage: string;
+  participating: boolean;
+}
+
+export const challengeCardList: ChallengeCardData[] = [
+  {
+    challengeMonth: 7,
+    challengeName: '친구와 함께하는 카공 챌린지',
+    challengeStartDate: '2025.07.01',
+    challengeDoneDate: '2025.07.31',
+    challengeImage:
+      'https://images.unsplash.com/photo-1529070538774-1843cb3265df?auto=format&fit=crop&w=400&q=80',
+    participating: true,
+  },
+  {
+    challengeMonth: 0,
+    challengeName: '친구와 함께하는 카공 챌린지',
+    challengeStartDate: '2025.07.01',
+    challengeDoneDate: '2025.07.31',
+    challengeImage:
+      'https://images.unsplash.com/photo-1529070538774-1843cb3265df?auto=format&fit=crop&w=400&q=80',
+    participating: true,
+  },
+  {
+    challengeMonth: 7,
+    challengeName: '친구와 함께하는 카공 챌린지',
+    challengeStartDate: '2025.07.01',
+    challengeDoneDate: '2025.07.31',
+    challengeImage:
+      'https://images.unsplash.com/photo-1529070538774-1843cb3265df?auto=format&fit=crop&w=400&q=80',
+    participating: false,
+  },
+  {
+    challengeMonth: 0,
+    challengeName: '친구와 함께하는 카공 챌린지',
+    challengeStartDate: '2025.07.01',
+    challengeDoneDate: '2025.07.31',
+    challengeImage:
+      'https://images.unsplash.com/photo-1529070538774-1843cb3265df?auto=format&fit=crop&w=400&q=80',
+    participating: true,
+  },
+  {
+    challengeMonth: 7,
+    challengeName: '친구와 함께하는 카공 챌린지',
+    challengeStartDate: '2025.07.01',
+    challengeDoneDate: '2025.07.31',
+    challengeImage:
+      'https://images.unsplash.com/photo-1529070538774-1843cb3265df?auto=format&fit=crop&w=400&q=80',
+    participating: false,
+  },
+  {
+    challengeMonth: 7,
+    challengeName: '친구와 함께하는 카공 챌린지',
+    challengeStartDate: '2025.07.01',
+    challengeDoneDate: '2025.07.31',
+    challengeImage:
+      'https://images.unsplash.com/photo-1529070538774-1843cb3265df?auto=format&fit=crop&w=400&q=80',
+    participating: false,
+  },
+  {
+    challengeMonth: 7,
+    challengeName: '친구와 함께하는 카공 챌린지',
+    challengeStartDate: '2025.07.01',
+    challengeDoneDate: '2025.07.31',
+    challengeImage:
+      'https://images.unsplash.com/photo-1529070538774-1843cb3265df?auto=format&fit=crop&w=400&q=80',
+    participating: false,
+  },
+  {
+    challengeMonth: 7,
+    challengeName: '친구와 함께하는 카공 챌린지',
+    challengeStartDate: '2025.07.01',
+    challengeDoneDate: '2025.07.31',
+    challengeImage:
+      'https://images.unsplash.com/photo-1529070538774-1843cb3265df?auto=format&fit=crop&w=400&q=80',
+    participating: false,
+  },
+];

--- a/Loopy-fe/src/pages/User/Home/components/TopBar.tsx
+++ b/Loopy-fe/src/pages/User/Home/components/TopBar.tsx
@@ -1,5 +1,5 @@
 import Bell from '../../../../assets/images/Bell.svg';
-import Bookmark from '../../../../assets/images/Bookmark.svg';
+import BookmarkWhite from '../../../../assets/images/BookmarkWhite.svg';
 import LoopyIconGreen from '../../../../assets/images/LoopyIconGreen.svg';
 import { useNavigate } from 'react-router-dom';
 
@@ -13,9 +13,8 @@ const TopBar = () => {
       </div>
       <div className="flex items-center gap-2">
         <button onClick={() => navigate('/bookmark')}>
-          <img src={Bookmark} alt="bookmark" className="w-6 h-6" />
+          <img src={BookmarkWhite} alt="bookmark" className="w-6 h-6" />
         </button>
-
         <button onClick={() => navigate('/alarm')}>
           <img src={Bell} alt="bell" className="w-6 h-6" />
         </button>


### PR DESCRIPTION
## 📌 변경사항
- 홈에서 이어지는 챌린지 리스트 페이지 구현

## ✅ 작업 내용 체크리스트
- [X] 챌린지 리스트 UI 구현
- [X] 목데이터 삽입 (챌린지 실행하는 달이 0인 경우에 '루피만의 챌린지!' 문구 뜨도록)
- [X] 참여 중인 챌린지 탭에서는 '참여 중' 태그 안 뜨게 설정

## 📷 스크린샷 or 영상 (선택)
![image](https://github.com/user-attachments/assets/6d000367-d14f-48a4-81de-789df719c566)
![image](https://github.com/user-attachments/assets/b6f8dfc1-ef69-4530-ad87-2fbab2466b6b)

## 🧪 테스트 방법 (선택)
> 어떻게 테스트했는지 설명해주세요.
