### PR TITLE
[Fix:#417] 이메일 인증 api 로직 수정

### DIFF
--- a/Loopy-fe/src/apis/auth/verifyEmail/api.ts
+++ b/Loopy-fe/src/apis/auth/verifyEmail/api.ts
@@ -1,0 +1,22 @@
+import axiosInstance from "../../axios";
+import type { EmailVerificationRequest, EmailVerificationVerifyRequest, VerificationResponse } from "./type";
+
+export const requestEmailVerification = async (
+  data: EmailVerificationRequest
+): Promise<VerificationResponse> => {
+  const res = await axiosInstance.post(
+    "/api/verification/email/request",
+    data
+  );
+  return res.data;
+};
+
+export const verifyEmailCode = async (
+  data: EmailVerificationVerifyRequest
+): Promise<VerificationResponse> => {
+  const res = await axiosInstance.post(
+    "/api/verification/email/verify",
+    data
+  );
+  return res.data;
+};

--- a/Loopy-fe/src/apis/auth/verifyEmail/type.ts
+++ b/Loopy-fe/src/apis/auth/verifyEmail/type.ts
@@ -1,0 +1,13 @@
+export interface EmailVerificationRequest {
+  email: string;
+}
+
+export interface EmailVerificationVerifyRequest {
+  email: string;
+  code: string;
+}
+
+export interface VerificationResponse {
+  success: boolean;
+  message: string;
+}

--- a/Loopy-fe/src/hooks/mutation/signin/useEmailVerification.ts
+++ b/Loopy-fe/src/hooks/mutation/signin/useEmailVerification.ts
@@ -1,69 +1,49 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
+import { requestEmailVerification, verifyEmailCode } from "../../../apis/auth/verifyEmail/api";
 
-/**
- * 임시 이메일 인증 훅
- * - email: 인증 요청용
- * - verifyCode: 사용자가 입력한 코드
- */
-export const useEmailVerification = (
-  email: string,
-  verifyCode: string
-) => {
-  // ===== 상태 =====
+export const useEmailVerification = (email: string, code: string) => {
   const [isRequested, setIsRequested] = useState(false);
   const [isVerified, setIsVerified] = useState(false);
-  const [verifyError, setVerifyError] = useState(false); 
-  const [serverCode, setServerCode] = useState<number | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
+  const [verifyError, setVerifyError] = useState(false);
 
-  // ===== 임시 API =====
-  const requestEmailVerifyCode = async (email: string): Promise<number> => {
-    console.log("📨 이메일 인증 요청:", email);
-
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        resolve(123456); // 임시 인증번호
-      }, 500);
-    });
-  };
-
-  // ===== 인증번호 요청 =====
-  const sendCode = async () => {
+  /** 인증번호 요청 */
+  const sendCode = useCallback(async () => {
     if (!email) return;
 
-    setIsLoading(true);
-
-    const code = await requestEmailVerifyCode(email);
-    setServerCode(code);
-
-    setIsRequested(true);
-    setIsVerified(false);
-    setVerifyError(false); 
-
-    setIsLoading(false);
-  };
-
-  // ===== 인증번호 검증 =====
-  const validateCode = () => {
-    if (!serverCode) return;
-
-    if (Number(verifyCode) === serverCode) {
-      setIsVerified(true);
+    try {
+      await requestEmailVerification({ email });
+      setIsRequested(true);
       setVerifyError(false);
-    } else {
-      setIsVerified(false);
+    } catch {
       setVerifyError(true);
     }
-  };
+  }, [email]);
+
+  /** 인증번호 검증 */
+  const validateCode = useCallback(async () => {
+    if (code.length !== 6) return;
+
+    try {
+      const res = await verifyEmailCode({ email, code });
+      if (res.success) {
+        setIsVerified(true);
+        setVerifyError(false);
+      } else {
+        setVerifyError(true);
+        setIsVerified(false);
+      }
+    } catch {
+      setVerifyError(true);
+      setIsVerified(false);
+    }
+  }, [email, code]);
 
   return {
     isRequested,
     isVerified,
     verifyError,
-    isLoading,
-
+    setVerifyError,
     sendCode,
     validateCode,
-    setVerifyError, 
   };
 };


### PR DESCRIPTION
## 📌 변경사항
- 이메일 기반 회원가입 과정에서 **이메일 인증번호 발송 및 인증번호 검증 기능을 구현**했습니다.
- 인증번호 6자리 입력 완료 시 자동으로 서버에 검증 요청이 전송되도록 로직을 개선했습니다.
- 이메일 인증 관련 상태를 커스텀 훅으로 분리하여 UI와 비즈니스 로직을 분리했습니다.


## ℹ️ 관련 이슈
- closes #417 


## ✅ 작업 내용 체크리스트
- [X] 이메일 인증 요청 API(`/api/verification/email/request`) 연동
- [X] 이메일 인증 코드 검증 API(`/api/verification/email/verify`) 연동
- [X] 인증번호 입력 완료(6자리) 시 자동 검증 로직 구현
- [X] 인증 요청/성공/실패 상태 관리 로직 분리 (`useEmailVerification`)
- [X] 이메일 형식 검증 및 인증 요청 버튼 활성/비활성 처리
- [X] 인증 실패 시 에러 UI 노출 처리


## 📷 스크린샷 or 영상 (선택)
- 이메일 입력 및 인증번호 입력 화면
- 인증 성공 / 실패 상태 화면


## 🧪 테스트 방법 (선택)
1. 유효한 이메일 입력 후 **인증번호 받기** 버튼 클릭
2. 해당 이메일로 수신된 인증번호 6자리 입력
3. 6자리 입력 완료 시 자동으로 인증 검증 요청이 전송되는지 확인
4. 올바른 인증번호 입력 시 회원가입 버튼이 활성화되는지 확인
5. 잘못된 인증번호 입력 시 에러 UI가 정상적으로 표시되는지 확인
