### PR TITLE
[Feat/#419] 인앱 브라우저 우회 접속 팝업창 구현

### DIFF
--- a/Loopy-fe/src/App.tsx
+++ b/Loopy-fe/src/App.tsx
@@ -38,199 +38,192 @@ import MapSearchProviders from './layouts/MapSearchProviderLayout.tsx';
 import VerifyPage from './pages/auth/VerifyPage.tsx';
 import { AuthCheck } from './utils/authCheck';
 import AppEntry from './pages/AppEntry.tsx';
+import GlobalLayout from './layouts/GlobalLayout';
 
 const publicRoutes = createBrowserRouter([
   {
-    path: '/',
+    element: <GlobalLayout />, 
     errorElement: <ErrorPage />,
-    element: <UserLayout />,
     children: [
       {
-        index: true,
-        element: <AppEntry />,
-        handle: { isPublic: true },
-      },
-      {
-        path: 'signin',
-        element: <SigninPage />,
-        handle: { isPublic: true },
-      },
-      {
-        path: 'login/success',
-        element: <LoginSuccess />,
-        handle: { isPublic: true },
-      },
-      {
-        path: 'verify',
-        loader: AuthCheck.authPageCheck,
-        element: <VerifyPage />,
-      },
-      {
-        path: 'onboard',
-        loader: AuthCheck.authPageCheck,
-        element: <OnboardingLayout />,
-      },
-      {
-        path: 'home',
-        loader: AuthCheck.authPageCheck,
-        element: <HomePage />,
-      },
-      {
-        path: 'map',
-        loader: AuthCheck.authPageCheck,
+        path: '/',
+        element: <UserLayout />,
         children: [
           {
             index: true,
-            element: (
-              <MapSearchProviders>
-                <MapPage />
-              </MapSearchProviders>
-            ),
+            element: <AppEntry />,
+            handle: { isPublic: true },
           },
-          { path: 'location', element: <LocationPage /> },
+          {
+            path: 'signin',
+            element: <SigninPage />,
+            handle: { isPublic: true },
+          },
+          {
+            path: 'login/success',
+            element: <LoginSuccess />,
+            handle: { isPublic: true },
+          },
+          {
+            path: 'verify',
+            loader: AuthCheck.authPageCheck,
+            element: <VerifyPage />,
+          },
+          {
+            path: 'onboard',
+            loader: AuthCheck.authPageCheck,
+            element: <OnboardingLayout />,
+          },
+          {
+            path: 'home',
+            loader: AuthCheck.authPageCheck,
+            element: <HomePage />,
+          },
+          {
+            path: 'map',
+            loader: AuthCheck.authPageCheck,
+            children: [
+              {
+                index: true,
+                element: (
+                  <MapSearchProviders>
+                    <MapPage />
+                  </MapSearchProviders>
+                ),
+              },
+              { path: 'location', element: <LocationPage /> },
+            ],
+          },
+          {
+            path: 'search',
+            loader: AuthCheck.authPageCheck,
+            children: [
+              {
+                index: true,
+                element: (
+                  <MapSearchProviders>
+                    <SearchPage />
+                  </MapSearchProviders>
+                ),
+              },
+              { path: 'location', element: <LocationPage /> },
+            ],
+          },
+          {
+            path: 'detail/:cafeId',
+            loader: AuthCheck.authPageCheck,
+            children: [
+              {
+                index: true,
+                element: <DetailPage />,
+              },
+              { path: 'menu', loader: AuthCheck.authPageCheck, element: <MenuListPage /> },
+              { path: 'write-review', loader: AuthCheck.authPageCheck, element: <ReviewWritePage /> },
+            ],
+          },
+          {
+            path: 'mypage',
+            loader: AuthCheck.authPageCheck,
+            element: <MyPageFunnelLayout />,
+          },
+          {
+            path: 'alarm',
+            loader: AuthCheck.authPageCheck,
+            element: <AlarmPage />,
+          },
+          {
+            path: 'bookmark',
+            loader: AuthCheck.authPageCheck,
+            element: <BookMarkPage />,
+          },
+          {
+            path: 'challenge',
+            loader: AuthCheck.authPageCheck,
+            element: <ChallengePage />,
+          },
+          {
+            path: 'challenge/:id',
+            loader: AuthCheck.authPageCheck,
+            element: <ChallengeDetailPage />,
+          },
+          {
+            path: 'challenge/:id/stores',
+            loader: AuthCheck.authPageCheck,
+            element: <ChallengeStoreListPage />,
+          },
+          {
+            path: 'level',
+            loader: AuthCheck.authPageCheck,
+            element: <LevelDetailPage />,
+          },
+          {
+            path: 'mystamppage/:stampBookId',
+            loader: AuthCheck.authPageCheck,
+            element: <MyStampPage />,
+          },
         ],
       },
       {
-        path: 'search',
-        loader: AuthCheck.authPageCheck,
+        path: '/admin',
+        element: <AdminLayout />,
         children: [
+          { index: true, element: <AdminLoginPage /> },
+          // {
+          //   path: 'login/success',
+          //   element: <AdminLoginSuccess />,
+          //   handle: { isPublic: true },
+          // },
           {
-            index: true,
-            element: (
-              <MapSearchProviders>
-                <SearchPage />
-              </MapSearchProviders>
-            ),
+            path: 'signin',
+            loader: AuthCheck.authPageCheck,
+            element: <AdminSigninPage />,
           },
-          { path: 'location', element: <LocationPage /> },
+          {
+            path: 'home',
+            loader: AuthCheck.authPageCheck,
+            element: <AdminHomePage />,
+          },
+          {
+            path: 'register',
+            loader: AuthCheck.authPageCheck,
+            element: <AdminRegisterPage />,
+          },
+          {
+            path: 'challenge',
+            loader: AuthCheck.authPageCheck,
+            element: <AdminChallengePage />,
+          },
+          {
+            path: 'challenge/:challengeId',
+            loader: AuthCheck.authPageCheck,
+            element: <AdminChallengeDetail />,
+          },
+          {
+            path: 'challengelist',
+            loader: AuthCheck.authPageCheck,
+            element: <AdminChallengeList />,
+          },
+          {
+            path: 'coupon/:cafeId',
+            loader: AuthCheck.authPageCheck,
+            element: <AdminCouponPage />,
+          },
+          {
+            path: 'stamp',
+            loader: AuthCheck.authPageCheck,
+            element: <AdminStampPage />,
+          },
+          {
+            path: 'notification',
+            loader: AuthCheck.authPageCheck,
+            element: <AdminNotificationPage />,
+          },
+          {
+            path: 'setting',
+            loader: AuthCheck.authPageCheck,
+            element: <AdminSettingFunnelLayout />,
+          },
         ],
-      },
-      {
-        path: 'detail/:cafeId',
-        loader: AuthCheck.authPageCheck,
-        children: [
-          {
-            index: true,
-            loader: AuthCheck.authPageCheck,
-            element: <DetailPage />,
-          },
-          {
-            path: 'menu',
-            loader: AuthCheck.authPageCheck,
-            element: <MenuListPage />,
-          },
-          {
-            path: 'write-review',
-            loader: AuthCheck.authPageCheck,
-            element: <ReviewWritePage />,
-          },
-        ],
-      },
-      {
-        path: 'mypage',
-        loader: AuthCheck.authPageCheck,
-        element: <MyPageFunnelLayout />,
-      },
-      {
-        path: 'alarm',
-        loader: AuthCheck.authPageCheck,
-        element: <AlarmPage />,
-      },
-      {
-        path: 'bookmark',
-        loader: AuthCheck.authPageCheck,
-        element: <BookMarkPage />,
-      },
-      {
-        path: 'challenge',
-        loader: AuthCheck.authPageCheck,
-        element: <ChallengePage />,
-      },
-      {
-        path: 'challenge/:id',
-        loader: AuthCheck.authPageCheck,
-        element: <ChallengeDetailPage />,
-      },
-      {
-        path: 'challenge/:id/stores',
-        loader: AuthCheck.authPageCheck,
-        element: <ChallengeStoreListPage />,
-      },
-      {
-        path: 'level',
-        loader: AuthCheck.authPageCheck,
-        element: <LevelDetailPage />,
-      },
-      {
-        path: 'mystamppage/:stampBookId',
-        loader: AuthCheck.authPageCheck,
-        element: <MyStampPage />,
-      },
-    ],
-  },
-  {
-    path: '/admin',
-    element: <AdminLayout />,
-    children: [
-      {
-        index: true,
-        element: <AdminLoginPage />,
-      },
-      // {
-      //   path: 'login/success',
-      //   element: <AdminLoginSuccess />,
-      //   handle: { isPublic: true },
-      // },
-      {
-        path: 'signin',
-        loader: AuthCheck.authPageCheck,
-        element: <AdminSigninPage />,
-      },
-      {
-        path: 'home',
-        loader: AuthCheck.authPageCheck,
-        element: <AdminHomePage />,
-      },
-      {
-        path: 'register',
-        loader: AuthCheck.authPageCheck,
-        element: <AdminRegisterPage />,
-      },
-      {
-        path: 'challenge',
-        loader: AuthCheck.authPageCheck,
-        element: <AdminChallengePage />,
-      },
-      {
-        path: 'challenge/:challengeId',
-        loader: AuthCheck.authPageCheck,
-        element: <AdminChallengeDetail />,
-      },
-
-      {
-        path: 'challengelist',
-        loader: AuthCheck.authPageCheck,
-        element: <AdminChallengeList />,
-      },
-      {
-        path: 'coupon/:cafeId',
-        loader: AuthCheck.authPageCheck,
-        element: <AdminCouponPage />,
-      },
-      {
-        path: 'stamp',
-        loader: AuthCheck.authPageCheck,
-        element: <AdminStampPage />,
-      },
-      {
-        path: 'notification',
-        loader: AuthCheck.authPageCheck,
-        element: <AdminNotificationPage />,
-      },
-      {
-        path: 'setting',
-        loader: AuthCheck.authPageCheck,
-        element: <AdminSettingFunnelLayout />,
       },
     ],
   },

--- a/Loopy-fe/src/components/popup/ExternalBrowserGuidePopup.tsx
+++ b/Loopy-fe/src/components/popup/ExternalBrowserGuidePopup.tsx
@@ -1,0 +1,48 @@
+import { useEffect } from 'react';
+import { openExternalBrowser } from '../../utils/browser.ts';
+
+interface Props {
+  onClose: () => void;
+}
+
+const ExternalBrowserGuidePopup = ({ onClose }: Props) => {
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, []);
+
+  return (
+    <div
+      className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/60"
+      onClick={onClose}
+    >
+      <div
+        className="w-[90%] max-w-[320px] rounded-[16px] bg-white px-6 py-5 text-center"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <p className="mb-5 text-[15px] font-semibold text-[#252525] leading-[1.4]">
+          원활한 서비스 이용을 위해<br />
+          외부 브라우저에서 열어주세요.
+        </p>
+
+        <button
+          onClick={openExternalBrowser}
+          className="mb-3 w-full rounded-[9px] bg-[#6970F3] py-[14px] text-[14px] font-semibold text-[#FFFFFF]"
+        >
+          열기
+        </button>
+
+        <button
+          onClick={onClose}
+          className="w-full rounded-[9px] bg-[#DFDFDF] py-[14px] text-[14px] font-semibold text-[#7F7F7F]"
+        >
+          취소
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ExternalBrowserGuidePopup;

--- a/Loopy-fe/src/hooks/useExternalBrowerGuide.ts
+++ b/Loopy-fe/src/hooks/useExternalBrowerGuide.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+import { isInAppBrowser, isPWA } from "../utils/browser";
+
+/**
+ * 인앱 브라우저(WebView)로 접속한 경우
+ * 항상 외부 브라우저 이동 안내를 노출하는 훅
+ */
+export const useExternalBrowserGuide = () => {
+  const [showGuide, setShowGuide] = useState(false);
+
+  useEffect(() => {
+    if (isInAppBrowser() && !isPWA()) {
+      setShowGuide(true);
+    }
+  }, []);
+
+  return {
+    showGuide,
+    closeGuide: () => setShowGuide(false),
+  };
+};
+

--- a/Loopy-fe/src/layouts/GlobalLayout.tsx
+++ b/Loopy-fe/src/layouts/GlobalLayout.tsx
@@ -1,0 +1,18 @@
+import { Outlet } from 'react-router-dom';
+import { useExternalBrowserGuide } from '../hooks/useExternalBrowerGuide.ts';
+import ExternalBrowserGuidePopup from '../components/popup/ExternalBrowserGuidePopup.tsx';
+
+const GlobalLayout = () => {
+  const { showGuide, closeGuide } = useExternalBrowserGuide();
+
+  return (
+    <>
+      <Outlet />
+      {showGuide && (
+        <ExternalBrowserGuidePopup onClose={closeGuide} />
+      )}
+    </>
+  );
+};
+
+export default GlobalLayout;

--- a/Loopy-fe/src/utils/browser.ts
+++ b/Loopy-fe/src/utils/browser.ts
@@ -1,0 +1,50 @@
+/**
+ * 모든 인앱 브라우저(WebView) 감지
+ * - 카카오, 인스타, 에타, 학교앱, 커뮤니티앱 등 포함
+ */
+export const isInAppBrowser = (): boolean => {
+  const ua = navigator.userAgent.toLowerCase();
+
+  const isAndroidWebView =
+    ua.includes("wv") ||
+    (ua.includes("android") && ua.includes("version/"));
+
+  const isIOSWebView =
+    /iphone|ipad|ipod/i.test(ua) &&
+    !ua.includes("safari");
+
+  return isAndroidWebView || isIOSWebView;
+};
+
+/**
+ * iOS 여부
+ */
+export const isIOS = (): boolean =>
+  /iphone|ipad|ipod/i.test(navigator.userAgent);
+
+/**
+ * PWA 실행 여부
+ */
+export const isPWA = (): boolean =>
+  window.matchMedia("(display-mode: standalone)").matches;
+
+/**
+ * 외부 브라우저로 열기
+ */
+export const openExternalBrowser = () => {
+  const currentUrl = window.location.href;
+
+  // iOS : Safari
+  if (isIOS()) {
+    window.open(currentUrl, "_blank");
+    return;
+  }
+
+  // Android : Chrome
+  const intentUrl =
+    `intent://${currentUrl.replace(/^https?:\/\//, "")}` +
+    `#Intent;scheme=https;package=com.android.chrome;end`;
+
+  window.location.href = intentUrl;
+};
+


### PR DESCRIPTION
## 📌 변경사항
- 인앱 브라우저(WebView) 환경에서 서비스 진입 시, 외부 브라우저 사용을 유도하는 전역 안내 팝업을 추가했습니다.
- iOS/Android 인앱 브라우저에서 `alert` 사용 시 안내가 노출되지 않는 문제를 방지하기 위해 커스텀 팝업 UI로 구현했습니다.
- User / Admin 모든 페이지에 공통 적용될 수 있도록 최상단 `GlobalLayout`을 추가했습니다.

## ℹ️ 관련 이슈
- closes #419 

## ✅ 작업 내용 체크리스트
- [X] 인앱 브라우저(UserAgent) 판별 유틸 함수 구현
- [X] 외부 브라우저(Safari / Chrome)로 이동하는 공통 유틸 함수 구현
- [X] 인앱 브라우저 진입 시 안내 팝업 노출을 위한 전역 훅 구현
- [X] GlobalLayout 추가 및 UserLayout / AdminLayout 공통 감싸기
- [X] 커스텀 팝업 UI 컴포넌트 구현 (확인 / 취소 버튼)
- [X] iOS 인앱 브라우저 환경에서도 정상 노출되는 방식으로 처리

## 📷 스크린샷 or 영상 (선택)
- 인앱 브라우저 환경 진입 시 외부 브라우저 이동 안내 팝업 노출 화면

## 🧪 테스트 방법 (선택)
1. 카카오톡 / 인스타그램 등 인앱 브라우저에서 서비스 URL 접속
2. 페이지 진입 시 외부 브라우저 이동 안내 팝업 노출 여부 확인
3. `열기` 버튼 클릭 시  
   - iOS: Safari로 정상 이동되는지 확인  
   - Android: Chrome Intent로 정상 이동되는지 확인
4. `취소` 버튼 클릭 시 팝업 닫힘 및 기존 페이지 정상 이용 가능 여부 확인
