### PR TITLE
[Fix/#425] 회원가입 누락된 API 연동

### DIFF
--- a/Loopy-fe/src/pages/Admin/Signin/_components/AdminSinginPage.tsx
+++ b/Loopy-fe/src/pages/Admin/Signin/_components/AdminSinginPage.tsx
@@ -88,7 +88,7 @@ const AdminSigninPage = ({ formData, setFormData, onNext, onBack }: Props) => {
           }`}
         >
         <CommonButton
-          text="다음으로 넘어가기"
+          text="회원가입하기"
           onClick={onNext}
           disabled={!isValid}
           className={`w-full ${

--- a/Loopy-fe/src/pages/Admin/Signin/index.tsx
+++ b/Loopy-fe/src/pages/Admin/Signin/index.tsx
@@ -1,12 +1,15 @@
 import { useState } from "react";
-import AdminSigninPage from "./_components/AdminSinginPage";
-import AdminSignupSuccess from "./_components/AdminSignupSuccess.tsx";
-import type { FormData } from "../../../types/form";
 import { useNavigate } from "react-router-dom";
+import AdminSigninPage from "./_components/AdminSinginPage";
+import AdminSignupSuccess from "./_components/AdminSignupSuccess";
+import type { FormData } from "../../../types/form";
+import { useSignup } from "../../../hooks/mutation/signin/useSignup";
+import type { SignupRequest } from "../../../apis/auth/signin/type";
 
 const AdminSigninPageIndex = () => {
-  const [step, setStep] = useState<"account" | "email" | "success">("account");
+  const [step, setStep] = useState<"account" | "success">("account");
   const navigate = useNavigate();
+  const { mutate: signupMutate } = useSignup();
 
   const [formData, setFormData] = useState<FormData>({
     email: "",
@@ -23,7 +26,31 @@ const AdminSigninPageIndex = () => {
     role: "OWNER",
   });
 
-  const handleSignupSuccess = () => setStep("success");
+  const handleSignup = () => {
+    const payload: SignupRequest = {
+      email: formData.email,
+      password: formData.password,
+      nickname: formData.nickname,
+      phoneNumber: formData.phoneNumber,
+      role: formData.role,
+      allowKakaoAlert: formData.allowKakaoAlert,
+      agreements: {
+        termsAgreed: formData.agreeTerms,
+        privacyPolicyAgreed: formData.agreePrivacy,
+        marketingAgreed: formData.agreemarketing,
+        locationPermission: formData.agreelocation,
+      },
+    };
+
+    signupMutate(payload, {
+      onSuccess: () => {
+        setStep("success");
+      },
+      onError: (err) => {
+        console.error("회원가입 실패:", err);
+      },
+    });
+  };
 
   return (
     <div className="w-full min-h-screen bg-white flex justify-center">
@@ -31,12 +58,14 @@ const AdminSigninPageIndex = () => {
         <AdminSigninPage
           formData={formData}
           setFormData={setFormData}
-          onNext={handleSignupSuccess}
+          onNext={handleSignup}
           onBack={() => navigate("/admin")}
         />
       )}
 
-      {step === "success" && <AdminSignupSuccess />}
+      {step === "success" && (
+        <AdminSignupSuccess />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## 📌 변경사항
- 관리자 회원가입(Signup) 플로우에서 누락되어 있던 POST 요청 로직을 추가하고,
- UI 전용 상태(FormData)와 API 요청 타입(SignupRequest) 간 매핑 구조를 정리하여
- 회원가입 성공 시 success 화면으로 정상 전환되도록 흐름을 수정했습니다.

## ℹ️ 관련 이슈
- closes #425 

## ✅ 작업 내용 체크리스트
- [X] 회원가입(Signup) API POST 요청 연결
- [X] FormData → SignupRequest 매핑 로직 추가
- [X] 약관 동의 데이터를 API 스펙에 맞게 `agreements` 객체로 변환
- [X] 회원가입 성공 시 success step 전환 처리
- [X] UI 컴포넌트와 비즈니스 로직 책임 분리

## 📷 스크린샷 or 영상 (선택)
- 회원가입 완료(success) 화면
- Network 탭에서 signup API 요청 확인 화면

## 🧪 테스트 방법 (선택)
- 이메일 인증, 비밀번호 검증, 약관 동의를 모두 완료한 후 “회원가입하기” 버튼 클릭
- Network 탭에서 signup POST 요청이 정상적으로 전송되는지 확인
- 서버 응답 성공 시 가입 완료 화면으로 전환되는지 확인
- “시작하기” 버튼 클릭 시 `/admin` 경로로 이동되는지 확인
