### PR TITLE
사장님 페이지 스탬프/QR 화면 추가

### DIFF
--- a/Loopy-fe/src/App.tsx
+++ b/Loopy-fe/src/App.tsx
@@ -32,6 +32,7 @@ import AdminSettingFunnelLayout from './layouts/AdminSettingFunnelLayout.tsx';
 import AdminChallengeList from './pages/Admin/Challenge/_components/AdminChallengeList.tsx';
 import AdminChallengeDetail from './pages/Admin/Challenge/_components/AdminChallengeDetail.tsx';
 import AdminNotificationPage from './pages/Admin/Notification/index.tsx';
+import AdminMembershipPage from './pages/Admin/Membership/index.tsx';
 import AdminRegisterPage from './pages/Admin/Register/index.tsx';
 import MapSearchProviders from './layouts/MapSearchProviderLayout.tsx';
 import VerifyPage from './pages/auth/VerifyPage.tsx';
@@ -211,6 +212,11 @@ const publicRoutes = createBrowserRouter([
             path: 'notification',
             loader: AuthCheck.authPageCheck,
             element: <AdminNotificationPage />,
+          },
+          {
+            path: 'membership',
+            loader: AuthCheck.authPageCheck,
+            element: <AdminMembershipPage />,
           },
           {
             path: 'setting',

--- a/Loopy-fe/src/components/admin/sideBar/CommonSideBar.tsx
+++ b/Loopy-fe/src/components/admin/sideBar/CommonSideBar.tsx
@@ -58,6 +58,12 @@ const menuItems: MenuItem[] = [
     icon: <AdminMessage />,
     iconSelected: <AdminMessagePurple />,
   },
+  {
+    label: '멤버십 적립',
+    path: '/admin/membership',
+    icon: <AdminMessage />,
+    iconSelected: <AdminMessagePurple />,
+  },
 ];
 
 const CommonSideBar = () => {

--- a/Loopy-fe/src/pages/Admin/Membership/index.tsx
+++ b/Loopy-fe/src/pages/Admin/Membership/index.tsx
@@ -1,0 +1,21 @@
+import HomeQRButton from '../Home/_components/HomeQRButton';
+import HomeStampButton from '../Home/_components/HomeStampButton';
+
+const AdminMembershipPage = () => {
+  return (
+    <div className="min-h-screen bg-white flex items-center justify-center">
+      <div className="w-full max-w-[44rem] px-6">
+        <div className="flex gap-4 justify-center">
+          <div className="w-[18rem]">
+            <HomeStampButton />
+          </div>
+          <div className="w-[18rem]">
+            <HomeQRButton />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AdminMembershipPage;


### PR DESCRIPTION
## 📌 변경사항
사장님 페이지 스탬프/QR 화면 따로 만들기
이후 카테고리 아이콘 수정 필요

## ℹ️ 관련 이슈
close #431 

## ✅ 작업 내용 체크리스트
- [X] 사이드바에 '멤버십 적립' 카테고리 추가
- [X] 카테고리 선택 시 스탬프/QR 적립 버튼 뜨도록 수정 

## 📷 스크린샷 or 영상 (선택)
<img width="1000" height="300" alt="image" src="https://github.com/user-attachments/assets/0c70929d-db95-4fdf-a552-9e203e02b4a0" />
<img width="1000" height="400" alt="image" src="https://github.com/user-attachments/assets/3c2f7307-eae5-48b3-8a25-1d3187a5c064" />
