### PR TITLE
[Fix/#433] 사장님 스텝 코임, 에러 수정

### DIFF
--- a/Loopy-fe/src/pages/Admin/Register/index.tsx
+++ b/Loopy-fe/src/pages/Admin/Register/index.tsx
@@ -10,7 +10,13 @@ import Step5Stamp from "./_steps/Step5Stamp";
 import AdminRegisterContentLayout from "../../../layouts/AdminRegisterContetntLayout";
 import { useAdminCafe } from "../../../contexts/AdminContext";
 
-const stepLabels = ["필요 서류 안내", "기본정보 입력", "운영정보 입력", "메뉴 등록", "스탬프 등록"];
+const stepLabels = [
+  "필요 서류 안내",
+  "기본정보 입력",
+  "운영정보 입력",
+  "메뉴 등록",
+  "스탬프 등록",
+];
 const LAST_STEP_INDEX = stepLabels.length - 1;
 
 export default function AdminRegisterPage() {
@@ -18,16 +24,28 @@ export default function AdminRegisterPage() {
   const navigate = useNavigate();
   const { activeCafeId } = useAdminCafe();
 
+  //step 계산 로직 - activeCafeId 있으면 Step1(0) 접근 금지
   const stepFromParams = useMemo(() => {
     const raw = searchParams.get("step");
     const n = Number(raw);
-    if (!Number.isFinite(n)) return 0;
-    if (n < 0) return 0;
-    if (n > LAST_STEP_INDEX) return LAST_STEP_INDEX;
-    return n;
-  }, [searchParams]);
 
-  const [step, setStep] = useState<number>(stepFromParams);
+    let step = Number.isFinite(n) ? n : 0; // URL의 step 값을 유효한 단계 번호로 정제
+    if (step < 0) step = 0;
+    if (step > LAST_STEP_INDEX) step = LAST_STEP_INDEX;
+
+    // 이미 카페 있을 경우에는 Step1 건너뛰기
+    if (activeCafeId && step === 0) {
+      return 1;
+    }
+
+    return step;
+  }, [searchParams, activeCafeId]);
+
+  const [step, setStep] = useState<number>(() => {
+    // 최초 진입 시 기본 step
+    return activeCafeId ? 1 : 0;
+  });
+
   const [_isStepValid, setIsStepValid] = useState(false);
 
   useEffect(() => {
@@ -37,7 +55,14 @@ export default function AdminRegisterPage() {
   }, [stepFromParams]);
 
   const goToStep = (next: number) => {
-    const safe = next < 0 ? 0 : next > LAST_STEP_INDEX ? LAST_STEP_INDEX : next;
+    let safe = next; // 임시 변수 - 이동하려는 단계 값을 상태로 넣어도 안전한 값으로 보정
+    if (safe < 0) safe = 0;
+    if (safe > LAST_STEP_INDEX) safe = LAST_STEP_INDEX;
+
+    if (activeCafeId && safe === 0) {
+      safe = 1;
+    }
+
     setStep(safe);
     setSearchParams({ step: String(safe) });
   };
@@ -53,19 +78,20 @@ export default function AdminRegisterPage() {
       navigate("/admin");
       return;
     }
+
     if (step === 1) {
       navigate(-1);
-    } else if (step > 0) {
+    } else {
       goToStep(step - 1);
     }
   };
 
   const renderStep = () => {
-    const props = { 
-      onNext: handleNext, 
-      onBack: handleBack, 
+    const props = {
+      onNext: handleNext,
+      onBack: handleBack,
       setValid: setIsStepValid,
-      cafeId: activeCafeId
+      cafeId: activeCafeId,
     };
 
     switch (step) {


### PR DESCRIPTION
## 📌 변경사항
- 사장님 카페 등록(Admin Register) 플로우에서 **중간 이탈 후 재진입 시 발생하던 카페 중복 생성 문제**를 해결하고,  
  step 기반 화면 전환 로직을 안정화한 PR입니다.
- 이미 생성된 카페가 있는 경우 Step1(카페 생성)을 자동으로 건너뛰고,  
  이후 단계(Step2~Step5)를 수정(PATCH/추가) 흐름으로 이어갈 수 있도록 개선했습니다.

## ℹ️ 관련 이슈
- closes #433 

## ✅ 작업 내용 체크리스트
- [X] 카페 등록 Step1(POST) 중복 호출 방지 로직 추가
- [X] `activeCafeId` 존재 여부에 따른 step 접근 제어
- [X] URL 파라미터(`?step=0`)를 통한 비정상 접근 보정
- [X] 중간 이탈 후 재진입 시에도 이어서 등록 가능하도록 UX 개선
- [X] step 계산 로직 가독성 및 안정성 개선

## 🔧 주요 개선 사항
### 1. Step1(카페 생성) 단일 호출 보장
- 로그인 시 이미 조회된 `activeCafeId`를 기준으로  
  카페 생성 POST API가 **최초 1회만 호출**되도록 방어 로직을 추가했습니다.
- 서버의 Unique Constraint 오류(500)를 프론트 로직에서 사전에 차단합니다.

### 2. Step 계산 로직 정리
- step 값은 URL 파라미터와 `activeCafeId`를 기준으로 계산하며,  
  이미 카페가 존재하는 경우 Step1 접근을 자동으로 차단합니다.
- step 보정 로직은 **파생 상태**이므로 별도의 state로 관리하지 않고 계산 로직으로 유지했습니다.

### 3. step 계산에서 `let`을 사용한 이유
- step 보정은 단일 렌더링 주기 내에서만 필요한 **임시 계산 로직**에 해당합니다.
- 리렌더링 간 유지될 필요가 없는 값이므로 `useState`가 아닌 `let`을 사용해  
  가독성과 의도를 명확히 했습니다.
- 최종 계산 결과만 React state로 반영하여 상태 관리 복잡도를 줄였습니다.

### 4. 중간 이탈 대응 UX 개선
- Step2~Step5는 PATCH/추가 API 구조이므로,  
  중간 이탈 후 재진입 시에도 기존 데이터를 기반으로 계속 수정할 수 있습니다.
- 사용자가 의도치 않게 처음 단계로 되돌아가는 문제를 방지했습니다.

## 📷 스크린샷 or 영상 (선택)
- (선택) 수정 전: Step1 재진입 시 서버 500 에러 발생 화면
- (선택) 수정 후: Step2부터 정상적으로 진입한 카페 등록 화면

## 🧪 테스트 방법 (선택)
- OWNER 계정으로 로그인 후 카페 미생성 상태에서 등록 플로우 정상 진행 확인
- Step1 완료 후 페이지 이탈 → 재진입 시 Step2부터 시작되는지 확인
- URL 파라미터로 `?step=0` 접근 시에도 Step1이 노출되지 않는지 확인
- 중간 단계(Step2~Step4) 입력 후 새로고침/재진입 시 PATCH 동작 정상 여부 확인
