### PR TITLE
[Fix:#435] 도로명 주소 -> 지번 주소로 변경

### DIFF
--- a/Loopy-fe/src/pages/Admin/Register/_components/ModalLocationSelector.tsx
+++ b/Loopy-fe/src/pages/Admin/Register/_components/ModalLocationSelector.tsx
@@ -9,9 +9,9 @@ import CloseIcon from '/src/assets/images/Close.svg?react';
 interface ModalLocationSelectorProps {
   onClose: () => void;
   onSave: (selectedRegion: {
-    region1DepthName: string;  
-    region2DepthName: string; 
-    region3DepthName: string; 
+    region1DepthName: string;
+    region2DepthName: string;
+    region3DepthName: string;
   }) => void;
 }
 
@@ -30,8 +30,17 @@ export default function ModalLocationSelector({
     isLoading,
   } = useSearchRegion();
 
+  // 시·동·구까지만 있는 주소는 숫자가 없음
+  const hasDetailAddress =
+    !!selected && /\d/.test(selected.address_name);
+
   const handleConfirm = () => {
     if (!selected) return;
+
+    // 시·동·구까지만 있는 경우 확정 불가
+    if (!/\d/.test(selected.address_name)) {
+      return;
+    }
 
     onSave({
       region1DepthName: selected.region_1depth_name,
@@ -87,13 +96,19 @@ export default function ModalLocationSelector({
         )}
       </div>
 
+      {selected && !hasDetailAddress && (
+        <p className="mt-2 text-[0.75rem] text-[#FF1E1E]">
+          번지(뒷번호)까지 포함된 주소를 선택해주세요.
+        </p>
+      )}
+
       <div className="w-full mt-[1.5rem] pb-[2rem]">
         <AddButton
           text="확정하기"
           onClick={handleConfirm}
-          disabled={!selected}
+          disabled={!hasDetailAddress}
           className={`w-full text-[1rem] flex items-center justify-center ${
-            selected
+            hasDetailAddress
               ? 'bg-[#6970F3] text-white'
               : 'bg-[#CCCCCC] text-[#7F7F7F] pointer-events-none'
           }`}

--- a/Loopy-fe/src/pages/Admin/Setting/_components/tabList/basic/AddressSearchField.tsx
+++ b/Loopy-fe/src/pages/Admin/Setting/_components/tabList/basic/AddressSearchField.tsx
@@ -60,7 +60,7 @@ const AddressSearchField = ({
       </div>
 
       <CommonInput
-        placeholder="도로명 주소를 입력해주세요 (OO로 OO길 OO)"
+        placeholder="지번 주소를 입력해주세요 (OO시 OO동 OO구)"
         value={address}
         readOnly
         onClick={() => setIsRoadModalOpen(true)}

--- a/Loopy-fe/src/pages/Admin/Setting/_components/tabList/basic/ModalRoadAddressSelector.tsx
+++ b/Loopy-fe/src/pages/Admin/Setting/_components/tabList/basic/ModalRoadAddressSelector.tsx
@@ -8,7 +8,10 @@ interface ModalRoadAddressSelectorProps {
   onSave: (picked: RoadAddressPick) => void;
 }
 
-export default function ModalRoadAddressSelector({ onClose, onSave }: ModalRoadAddressSelectorProps) {
+export default function ModalRoadAddressSelector({
+  onClose,
+  onSave,
+}: ModalRoadAddressSelectorProps) {
   const {
     input,
     setInput,
@@ -28,7 +31,9 @@ export default function ModalRoadAddressSelector({ onClose, onSave }: ModalRoadA
   return (
     <div className="w-[37rem] h-[35.75rem] bg-white rounded-[1rem] pt-[2rem] px-[2rem] flex flex-col">
       <div className="w-full flex justify-between items-center mb-[1.25rem]">
-        <h2 className="text-[1.25rem] font-bold text-black">도로명 주소 검색</h2>
+        <h2 className="text-[1.25rem] font-bold text-black">
+          도로명 주소 검색
+        </h2>
         <button onClick={onClose} className="text-[#7F7F7F] text-[1rem]">
           <CloseIcon />
         </button>
@@ -57,22 +62,30 @@ export default function ModalRoadAddressSelector({ onClose, onSave }: ModalRoadA
         ) : results.length > 0 ? (
           results.map((r, i) => {
             const isSelected = selected?.roadAddress === r.roadAddress;
+
             return (
               <div
                 key={i}
-                className={`px-[1rem] py-[1.25rem] rounded-[8px] text-[1rem] font-medium cursor-pointer mb-2 transition
+                className={`px-[1rem] py-[1.25rem] rounded-[8px] cursor-pointer mb-2 transition
                   ${isSelected ? "bg-[#F0F1FE]" : "bg-white"}`}
                 onClick={() => setSelected(r)}
               >
-                <p className="text-black">{r.roadAddress}</p>
-                {r.jibunAddress && (
-                  <p className="text-sm text-gray-500 mt-1">{r.jibunAddress}</p>
-                )}
+                {/* 큰 텍스트: 지번 주소 (시·동·구) */}
+                <p className="text-black text-[1rem] font-medium">
+                  {r.jibunAddress ?? r.roadAddress}
+                </p>
+
+                {/* 작은 텍스트: 도로명 주소 */}
+                <p className="text-sm text-gray-500 mt-1">
+                  {r.roadAddress}
+                </p>
               </div>
             );
           })
         ) : (
-          <p className="text-center text-gray-400 mt-4">검색 결과가 없습니다.</p>
+          <p className="text-center text-gray-400 mt-4">
+            검색 결과가 없습니다.
+          </p>
         )}
       </div>
 


### PR DESCRIPTION
## 📌 변경사항
- 주소 선택 모달에서 **시·동·구까지만 선택되는 문제를 개선**하여,
  번지(뒷번호)까지 포함된 상세 주소만 확정할 수 있도록 UX를 수정했습니다.

## ℹ️ 관련 이슈
- closes #435 

## ✅ 작업 내용 체크리스트
- [X] 주소 선택 UX 개선
- [X] 상세 주소(번지) 미포함 시 확정 버튼 비활성화
- [X] 사용자 안내 문구 추가로 선택 기준 명확화
- [X] 주소 확정 로직에서 최종 방어 조건 추가

## 📷 스크린샷 or 영상 (선택)
- (선택) 시·동·구까지만 선택했을 때 확정 버튼이 비활성화된 화면
- (선택) 번지 포함 주소 선택 시 정상적으로 확정 가능한 화면

## 🧪 테스트 방법 (선택)
- 주소 검색 후 시·동·구까지만 포함된 항목 선택 시 확정 버튼 비활성화 확인
- 번지(숫자) 포함 주소 선택 시 확정 버튼 활성화 및 정상 저장 여부 확인
- Enter 키 검색, 리스트 클릭, 현재 위치 설정 플로우 전반 동작 확인
