### PR TITLE
[Fix/#435] 지번 주소 모달창 수정

### DIFF
--- a/Loopy-fe/src/hooks/useJibunAddressSearch.ts
+++ b/Loopy-fe/src/hooks/useJibunAddressSearch.ts
@@ -1,0 +1,55 @@
+import { useState, useCallback } from "react";
+import { searchAddress } from "../apis/kakao/address";
+
+export type JibunAddressPick = {
+  jibunAddress: string;    
+  roadAddress?: string;   
+  x: string;
+  y: string;
+};
+
+export const useJibunAddressSearch = () => {
+  const [input, setInput] = useState("");
+  const [results, setResults] = useState<JibunAddressPick[]>([]);
+  const [selected, setSelected] = useState<JibunAddressPick | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const search = useCallback(async () => {
+    const keyword = input.trim();
+    if (!keyword) return;
+
+    setIsLoading(true);
+    try {
+      const docs = await searchAddress(keyword);
+
+      const list: JibunAddressPick[] = (docs ?? [])
+        .map((d: any) => {
+          const jibun = d.address_name ?? "";
+          if (!jibun) return null;
+
+          return {
+            jibunAddress: jibun,
+            roadAddress: d.road_address_name ?? undefined,
+            x: String(d.x ?? ""),
+            y: String(d.y ?? ""),
+          };
+        })
+        .filter(Boolean) as JibunAddressPick[];
+
+      setResults(list.slice(0, 20));
+      setSelected(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [input]);
+
+  return {
+    input,
+    setInput,
+    results,
+    selected,
+    setSelected,
+    search,
+    isLoading,
+  };
+};

--- a/Loopy-fe/src/pages/Admin/Register/_components/ModalLocationSelector.tsx
+++ b/Loopy-fe/src/pages/Admin/Register/_components/ModalLocationSelector.tsx
@@ -9,9 +9,9 @@ import CloseIcon from '/src/assets/images/Close.svg?react';
 interface ModalLocationSelectorProps {
   onClose: () => void;
   onSave: (selectedRegion: {
-    region1DepthName: string;
-    region2DepthName: string;
-    region3DepthName: string;
+    region1DepthName: string;  
+    region2DepthName: string; 
+    region3DepthName: string; 
   }) => void;
 }
 
@@ -30,17 +30,8 @@ export default function ModalLocationSelector({
     isLoading,
   } = useSearchRegion();
 
-  // 시·동·구까지만 있는 주소는 숫자가 없음
-  const hasDetailAddress =
-    !!selected && /\d/.test(selected.address_name);
-
   const handleConfirm = () => {
     if (!selected) return;
-
-    // 시·동·구까지만 있는 경우 확정 불가
-    if (!/\d/.test(selected.address_name)) {
-      return;
-    }
 
     onSave({
       region1DepthName: selected.region_1depth_name,
@@ -96,19 +87,13 @@ export default function ModalLocationSelector({
         )}
       </div>
 
-      {selected && !hasDetailAddress && (
-        <p className="mt-2 text-[0.75rem] text-[#FF1E1E]">
-          번지(뒷번호)까지 포함된 주소를 선택해주세요.
-        </p>
-      )}
-
       <div className="w-full mt-[1.5rem] pb-[2rem]">
         <AddButton
           text="확정하기"
           onClick={handleConfirm}
-          disabled={!hasDetailAddress}
+          disabled={!selected}
           className={`w-full text-[1rem] flex items-center justify-center ${
-            hasDetailAddress
+            selected
               ? 'bg-[#6970F3] text-white'
               : 'bg-[#CCCCCC] text-[#7F7F7F] pointer-events-none'
           }`}

--- a/Loopy-fe/src/pages/Admin/Register/_steps/Step2BasicInfo.tsx
+++ b/Loopy-fe/src/pages/Admin/Register/_steps/Step2BasicInfo.tsx
@@ -184,7 +184,7 @@ export default function Step2BasicInfo({ cafeId, setValid, onNext }: Step2BasicI
               />
             </div>
             <BasicInput
-              placeholder="도로명 주소를 입력해주세요 (OO로 OO)"
+              placeholder="지번 주소를 입력해주세요 (OO시 OO구 OO동)"
               value={address}
               readOnly
               onClick={() => setIsRoadModalOpen(true)}
@@ -300,7 +300,7 @@ export default function Step2BasicInfo({ cafeId, setValid, onNext }: Step2BasicI
           <ModalRoadAddressSelector
             onClose={() => setIsRoadModalOpen(false)}
             onSave={(selected) => {
-              setAddress(selected.roadAddress);
+              setAddress(selected.jibunAddress ?? '');
               setLatitude(Number(selected.y));
               setLongitude(Number(selected.x));
               setIsRoadModalOpen(false);

--- a/Loopy-fe/src/pages/Admin/Setting/_components/tabList/basic/AddressSearchField.tsx
+++ b/Loopy-fe/src/pages/Admin/Setting/_components/tabList/basic/AddressSearchField.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import CommonInput from "../../../../../../components/input/CommonInput";
 import ModalLocationSelector from "../../../../Register/_components/ModalLocationSelector";
 import ModalRoadAddressSelector from "./ModalRoadAddressSelector";
-import type { RoadAddressPick } from "../../../../../../hooks/useAddressSearch";
+import type { JibunAddressPick } from "../../../../../../hooks/useJibunAddressSearch";
 
 interface PickedAddress {
   region1DepthName?: string;
@@ -86,14 +86,15 @@ const AddressSearchField = ({
         <div className="fixed inset-0 z-50 bg-black/50 flex justify-center items-center">
           <ModalRoadAddressSelector
             onClose={() => setIsRoadModalOpen(false)}
-            onSave={(selected: RoadAddressPick) => {
-              setAddress(selected.roadAddress);
+            onSave={(selected: JibunAddressPick) => {
+              setAddress(selected.jibunAddress);
               updatePicked({
-                roadAddress: selected.roadAddress,
                 jibunAddress: selected.jibunAddress,
+                roadAddress: selected.roadAddress,
                 latitude: Number(selected.y),
                 longitude: Number(selected.x),
               });
+
               setIsRoadModalOpen(false);
             }}
           />

--- a/Loopy-fe/src/pages/Admin/Setting/_components/tabList/basic/ModalRoadAddressSelector.tsx
+++ b/Loopy-fe/src/pages/Admin/Setting/_components/tabList/basic/ModalRoadAddressSelector.tsx
@@ -1,11 +1,12 @@
-import { useRoadAddressSearch, type RoadAddressPick } from "../../../../../../hooks/useAddressSearch";
+import { useJibunAddressSearch, type JibunAddressPick } 
+  from "../../../../../../hooks/useJibunAddressSearch";
 import AddButton from "../../../../Register/_components/AddButton";
 import SearchIcon from "/src/assets/images/Search.svg?react";
 import CloseIcon from "/src/assets/images/Close.svg?react";
 
 interface ModalRoadAddressSelectorProps {
   onClose: () => void;
-  onSave: (picked: RoadAddressPick) => void;
+  onSave: (picked: JibunAddressPick) => void;
 }
 
 export default function ModalRoadAddressSelector({
@@ -20,10 +21,20 @@ export default function ModalRoadAddressSelector({
     setSelected,
     search,
     isLoading,
-  } = useRoadAddressSearch();
+  } = useJibunAddressSearch();
+
+  // ✅ 지번 주소에 숫자가 포함되어 있는지 (번지 여부)
+  const hasDetailAddress =
+    !!selected && /\d/.test(selected.jibunAddress);
 
   const handleConfirm = () => {
     if (!selected) return;
+
+    // ❌ 시·구·동까지만 있는 지번 주소는 확정 불가
+    if (!/\d/.test(selected.jibunAddress)) {
+      return;
+    }
+
     onSave(selected);
     onClose();
   };
@@ -32,9 +43,9 @@ export default function ModalRoadAddressSelector({
     <div className="w-[37rem] h-[35.75rem] bg-white rounded-[1rem] pt-[2rem] px-[2rem] flex flex-col">
       <div className="w-full flex justify-between items-center mb-[1.25rem]">
         <h2 className="text-[1.25rem] font-bold text-black">
-          도로명 주소 검색
+          지번 주소 검색
         </h2>
-        <button onClick={onClose} className="text-[#7F7F7F] text-[1rem]">
+        <button onClick={onClose} className="text-[#7F7F7F]">
           <CloseIcon />
         </button>
       </div>
@@ -44,7 +55,7 @@ export default function ModalRoadAddressSelector({
           type="text"
           value={input}
           onChange={(e) => setInput(e.target.value)}
-          placeholder="도로명 주소 입력"
+          placeholder="지번 주소 입력"
           className="flex-1 text-[1rem] bg-transparent border-none outline-none"
           onKeyDown={(e) => {
             if (e.key === "Enter") search();
@@ -61,7 +72,8 @@ export default function ModalRoadAddressSelector({
           <p className="text-center text-gray-500 mt-4">검색 중...</p>
         ) : results.length > 0 ? (
           results.map((r, i) => {
-            const isSelected = selected?.roadAddress === r.roadAddress;
+            const isSelected = selected?.jibunAddress === r.jibunAddress;
+            const isValid = /\d/.test(r.jibunAddress);
 
             return (
               <div
@@ -70,15 +82,21 @@ export default function ModalRoadAddressSelector({
                   ${isSelected ? "bg-[#F0F1FE]" : "bg-white"}`}
                 onClick={() => setSelected(r)}
               >
-                {/* 큰 텍스트: 지번 주소 (시·동·구) */}
                 <p className="text-black text-[1rem] font-medium">
-                  {r.jibunAddress ?? r.roadAddress}
+                  {r.jibunAddress}
                 </p>
 
-                {/* 작은 텍스트: 도로명 주소 */}
-                <p className="text-sm text-gray-500 mt-1">
-                  {r.roadAddress}
-                </p>
+                {r.roadAddress && (
+                  <p className="text-sm text-gray-500 mt-1">
+                    {r.roadAddress}
+                  </p>
+                )}
+
+                {!isValid && (
+                  <p className="text-xs text-red-500 mt-1">
+                    번지 정보가 없는 주소입니다. 상세 주소를 선택해주세요.
+                  </p>
+                )}
               </div>
             );
           })
@@ -93,9 +111,9 @@ export default function ModalRoadAddressSelector({
         <AddButton
           text="확정하기"
           onClick={handleConfirm}
-          disabled={!selected}
+          disabled={!hasDetailAddress}
           className={`w-full text-[1rem] flex items-center justify-center ${
-            selected
+            hasDetailAddress
               ? "bg-[#6970F3] text-white"
               : "bg-[#CCCCCC] text-[#7F7F7F] pointer-events-none"
           }`}


### PR DESCRIPTION
## 📌 변경사항
- 주소 입력 플로우를 **행정구역 선택 + 지번 주소 선택** 구조로 개선
- 도로명 주소 중심이던 UI를 **지번 주소 중심**으로 변경하여 실제 위치 정확도 강화
- 시·구·동까지만 선택되는 경우 확정 불가하도록 validation 추가

## ℹ️ 관련 이슈
- closes #435 

## ✅ 작업 내용 체크리스트
- [X] 주소 선택 UX 개선 (시·구·동 / 지번 주소 분리)
- [X] 지번 주소 선택 모달 신규 적용
- [X] 번지(숫자) 없는 주소 선택 차단 로직 추가
- [X] 선택된 주소 좌표(latitude / longitude) 연동
- [X] 기존 BasicInput placeholder 및 UI 유지

## 📷 스크린샷 or 영상 (선택)
- 주소 선택 모달 및 지번 주소 선택 화면

## 🧪 테스트 방법 (선택)
1. 기본정보 입력 단계에서 **주소 검색하기** 버튼 클릭
2. 시·구·동 선택 후 지번 주소 검색 모달 진입
3. 번지 없는 주소 선택 시 확정 버튼 비활성화 확인
4. 번지 포함 지번 주소 선택 후 확정
5. 선택한 주소가 입력창에 정상 반영되고 다음 단계로 이동되는지 확인
