### PR TITLE
Fix(#442) : 챌린지 상세 페이지 하드 코딩 부분 수정

### DIFF
--- a/Loopy-fe/src/pages/User/ChallengeDetail/index.tsx
+++ b/Loopy-fe/src/pages/User/ChallengeDetail/index.tsx
@@ -54,12 +54,11 @@ const ChallengeDetailPage = () => {
             {challenge.title}
           </h1>
 
-          {challenge.isParticipated && (
-            <p className="bg-[#F0F1FE] rounded text-[#6970F3] text-[0.875rem] font-semibold mt-6 px-[0.75rem] py-[0.25rem]">
-              카페 위니에서 참여 중
-            </p>
-          )}
-
+          {challenge.isParticipated && challenge.joinedCafe?.name && (
+  <p className="bg-[#F0F1FE] rounded text-[#6970F3] text-[0.875rem] font-semibold mt-6 px-[0.75rem] py-[0.25rem]">
+    {challenge.joinedCafe.name}에서 참여 중
+  </p>
+)}
           {/* 구분선 */}
           <div className="w-full max-w-md h-px bg-[#E0E0E0] mt-6 mb-4" />
 


### PR DESCRIPTION
## 📌 변경사항
챌린지 상세 페이지 '카페 위니'로 하드 코딩 된 부분 챌린지 참여 매장 명으로 출력되도록 수정

## ℹ️ 관련 이슈
close #442 

## 📷 스크린샷 or 영상 (선택)
<img width="382" height="338" alt="image" src="https://github.com/user-attachments/assets/2a79a037-2e09-4d16-a588-b0c963f6ea32" />
