### PR TITLE
[Fix/#444] 카카오 로그인 이후 전화번호 등록 로직 재구현

### DIFF
--- a/Loopy-fe/src/pages/User/Home/index.tsx
+++ b/Loopy-fe/src/pages/User/Home/index.tsx
@@ -119,8 +119,8 @@ const HomePage = () => {
       <CommonBottomPopup
         show={showPopup}
         onClose={() => setShowPopup(false)}
-        titleText={"카카오로 로그인하려면\n전화번호 인증이 필요해요"}
-        purpleButton="전화번호 인증하러 가기"
+        titleText={"서비스 이용 및 스탬프 적립을 위해\n전화번호 등록이 필요해요"}
+        purpleButton="전화번호 등록하러 가기"
         purpleButtonOnClick={() => navigate("/verify")}
         disableClose={true} 
       />

--- a/Loopy-fe/src/pages/auth/VerifyPage.tsx
+++ b/Loopy-fe/src/pages/auth/VerifyPage.tsx
@@ -1,81 +1,86 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import CommonHeader from "../../components/header/CommonHeader";
-import EmailInput from "../User/Signin/_components/verify/EmailInput";
-import VerifyCodeInput from "../Admin/Signin/_components/AdminVerifyCodeInput";
-import { useEmailVerification } from "../../hooks/mutation/signin/useEmailVerification";
-import { useKeyboardOpen } from "../../hooks/useKeyboardOpen";
 import CommonButton from "../../components/button/CommonButton";
+import { useSavePhone } from "../../hooks/mutation/verify/useSavePhone";
+import { useKeyboardOpen } from "../../hooks/useKeyboardOpen";
+import { useQueryClient } from "@tanstack/react-query";
+import { getIsDummyPhone } from "../../apis/auth/phoneCheck/api";
 
 const VerifyPage = () => {
   const navigate = useNavigate();
   const isKeyboardOpen = useKeyboardOpen();
+  const queryClient = useQueryClient();
 
-  const [email, setEmail] = useState("");
-  const [verifyCode, setVerifyCode] = useState("");
+  const [phoneNumber, setPhoneNumber] = useState("");
 
-  const {
-    isRequested,
-    verifyError,
-    sendCode,
-    setVerifyError,
-    isVerified,
-    validateCode,
-  } = useEmailVerification(email, verifyCode);
+  const { mutateAsync: savePhone, isPending } = useSavePhone();
 
-  useEffect(() => {
-    if (verifyCode.length === 6) {
-      validateCode();
+  const normalizePhone = (num: string) => {
+    const normalized = num.replace(/-/g, "");
+    if (normalized.startsWith("+82")) {
+      return "0" + normalized.slice(3);
     }
-  }, [verifyCode, validateCode]);
+    return normalized;
+  };
 
-  const handleBack = () => navigate(-1);
+  const formatPhoneNumber = (value: string) => {
+    const numbers = value.replace(/\D/g, "");
 
-  const isEmailValid =
-    email.includes("@") &&
-    !email.startsWith("@") &&
-    !email.endsWith("@");
+    if (numbers.length <= 3) return numbers;
+    if (numbers.length <= 7)
+      return `${numbers.slice(0, 3)}-${numbers.slice(3)}`;
+
+    return `${numbers.slice(0, 3)}-${numbers.slice(3, 7)}-${numbers.slice(7, 11)}`;
+  };
+
+  const handleSavePhone = async () => {
+    try {
+      const normalizedPhone = normalizePhone(phoneNumber);
+
+      await savePhone({ phoneNumber: normalizedPhone });
+
+      const result = await queryClient.fetchQuery({
+        queryKey: ["isDummyPhone"],
+        queryFn: () => getIsDummyPhone(),
+      });
+
+      if (result.isDummy || !result.phoneNumber?.startsWith("010")) {
+        console.error("더미 번호 또는 유효하지 않은 번호");
+        return;
+      }
+
+      navigate("/home", { replace: true });
+    } catch (err) {
+      console.error("전화번호 저장 실패", err);
+    }
+  };
 
   return (
     <div className="min-h-[100dvh] flex flex-col">
-      <CommonHeader title="이메일 인증" onBack={handleBack} />
+      <CommonHeader title="전화번호" onBack={() => navigate(-1)} />
 
       <main className="flex-1 pt-6">
         <p className="text-[1rem] font-semibold text-[#252525] mb-2">
-          이메일
+          전화번호
         </p>
 
-        <div className="flex gap-2 items-center justify-center">
-          <div className="flex-1">
-            <EmailInput email={email} onChange={setEmail} />
-          </div>
-
-          <button
-            disabled={!isEmailValid}
-            onClick={sendCode}
-            className={`text-[0.875rem] font-semibold px-4 h-[3.375rem] py-2 rounded-[9px] ${
-              isEmailValid
-                ? "bg-[#6970F3] text-white"
-                : "bg-[#DFDFDF] text-[#7F7F7F]"
-            }`}
-          >
-            인증번호 받기
-          </button>
-        </div>
-
-        {isRequested && (
-          <div className="mt-4">
-            <VerifyCodeInput
-              value={verifyCode}
-              onChange={(code) => {
-                setVerifyError(false);
-                setVerifyCode(code);
-              }}
-              hasError={verifyError}
-              onResend={sendCode}
-            />
-          </div>
-        )}
+        <input
+          value={phoneNumber}
+          onChange={(e) => setPhoneNumber(formatPhoneNumber(e.target.value))}
+          inputMode="numeric"
+          placeholder="스탬프 적립을 위해 전화번호를 입력해주세요"
+          className="
+            w-full h-[3.375rem]
+            px-4
+            rounded-[9px]
+            bg-[#F4F4F4]
+            text-[0.95rem]
+            text-[#252525]
+            placeholder:text-[#9A9A9A]
+            outline-none
+          "
+        />
       </main>
 
       <div
@@ -84,14 +89,14 @@ const VerifyPage = () => {
         }`}
       >
         <CommonButton
-          text="이메일 인증 완료"
-          onClick={() => navigate("/home", { replace: true })}
+          text="저장하기"
+          onClick={handleSavePhone}
+          disabled={phoneNumber.replace(/\D/g, "").length !== 11 || isPending}
           className={`w-full ${
-            isVerified
+            phoneNumber.replace(/\D/g, "").length === 11
               ? "bg-[#6970F3] text-white"
               : "bg-[#CCCCCC] text-[#7F7F7F]"
           }`}
-          disabled={!isVerified}
         />
       </div>
     </div>


### PR DESCRIPTION
## 📌 변경사항
- 전화번호 입력 화면 단순화 및 불필요한 인증 UI 제거
- 전화번호 저장 로직 유지 및 더미 번호 검증 흐름 정리
- 전화번호 입력 UX 개선 (자동 하이픈 포맷 적용)

## ℹ️ 관련 이슈
- closes #444 

## ✅ 작업 내용 체크리스트
- [X] 전화번호 입력 화면 UI 정리
- [X] 전화번호 저장 API 연동 유지
- [X] 더미 번호 여부 체크 로직 유지
- [X] 입력 UX 개선 (숫자 입력 시 자동 포맷)

## 📷 스크린샷 or 영상 (선택)

<img width="156" height="323" alt="image" src="https://github.com/user-attachments/assets/ed2bac38-d6c2-4efd-a81d-3d495d21b877" />

## 🧪 테스트 방법 (선택)
- 전화번호 입력 후 저장 버튼 클릭
- 정상 번호(010으로 시작) 입력 시 홈 화면 이동 확인
- 더미 번호 또는 비정상 번호 입력 시 이동되지 않는 것 확인
