### PR TITLE
[Fix/#444] 회원가입 페이지 전화번호 추가

### DIFF
--- a/Loopy-fe/src/pages/Admin/Signin/_components/AdminProfilePage.tsx
+++ b/Loopy-fe/src/pages/Admin/Signin/_components/AdminProfilePage.tsx
@@ -1,0 +1,62 @@
+import { useKeyboardOpen } from "../../../../hooks/useKeyboardOpen";
+import CommonButton from "../../../../components/button/CommonButton";
+import CommonHeader from "../../../../components/header/CommonHeader";
+import AdminNicknameSection from "./sections/AdminNicknameSection";
+import AdminPhoneSection from "./sections/AdminPhoneSection";
+import type { FormData } from "../../../../types/form";
+
+interface Props {
+  formData: FormData;
+  setFormData: React.Dispatch<React.SetStateAction<FormData>>;
+  onNext: () => void;
+  onBack: () => void;
+}
+
+const AdminProfilePage = ({ formData, setFormData, onNext, onBack }: Props) => {
+  const isKeyboardOpen = useKeyboardOpen();
+
+  const isValid =
+    !!formData.nickname &&
+    !!formData.phoneNumber;
+
+  return (
+    <div className="min-h-screen w-full bg-white flex flex-col font-suit">
+      <CommonHeader title="회원가입" onBack={onBack} />
+
+      <div className="flex-1 pt-[1.5rem] pb-[8rem] max-w-[34rem] mx-auto w-full">
+        <AdminNicknameSection
+          value={formData.nickname}
+          onChange={(nickname) =>
+            setFormData((p) => ({ ...p, nickname }))
+          }
+        />
+
+        <AdminPhoneSection
+          value={formData.phoneNumber}
+          onChange={(phoneNumber) =>
+            setFormData((p) => ({ ...p, phoneNumber }))
+          }
+        />
+      </div>
+
+      <div
+        className={`absolute left-1/2 translate-x-[-50%] w-full max-w-[34rem] flex flex-col items-center transition-all duration-300 ${
+          isKeyboardOpen ? "bottom-[4rem]" : "bottom-[2rem]"
+        }`}
+      >
+        <CommonButton
+          text="회원가입하기"
+          onClick={onNext}
+          disabled={!isValid}
+          className={`w-full ${
+            isValid
+              ? "bg-[#6970F3] text-white"
+              : "bg-[#CCCCCC] text-[#7F7F7F] pointer-events-none"
+          }`}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default AdminProfilePage;

--- a/Loopy-fe/src/pages/Admin/Signin/_components/AdminSignupSuccess.tsx
+++ b/Loopy-fe/src/pages/Admin/Signin/_components/AdminSignupSuccess.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import SuccessIcon from "../../../../assets/images/SuccessIcon.svg?react";
 import CommonButton from "../../../../components/button/CommonButton";
@@ -5,25 +6,39 @@ import CommonButton from "../../../../components/button/CommonButton";
 const AdminSignupSuccess = () => {
   const navigate = useNavigate();
 
+  // 뒤로가기 시 /admin으로 강제 이동
+  useEffect(() => {
+    const handlePopState = () => {
+      navigate("/admin", { replace: true });
+    };
+
+    window.addEventListener("popstate", handlePopState);
+
+    return () => {
+      window.removeEventListener("popstate", handlePopState);
+    };
+  }, [navigate]);
+
   const handleClick = () => {
-    navigate("/admin");
+    navigate("/admin", { replace: true });
   };
 
   return (
     <div className="relative min-h-screen w-full bg-white font-suit flex flex-col items-center justify-center">
-
       <div className="w-full max-w-[34rem] flex flex-col items-center text-center mt-[3rem]">
         <SuccessIcon className="w-[3.5rem] h-[3.5rem] mb-[2rem]" />
 
         <h1 className="text-[1.5rem] font-bold text-[#252525] mb-[1rem]">
           가입이 완료되었습니다!
         </h1>
+
         <p className="text-[1rem] text-[#7F7F7F] font-medium mb-[3.5rem] leading-[120%]">
           루피와 함께 고객이 끊이지 않는 고객관리를 시작하세요
         </p>
 
         <div
-          className={`absolute left-1/2 translate-x-[-50%] w-full max-w-[34rem] flex flex-col items-center transition-all duration-300 bottom-[2rem]`}
+          className="absolute left-1/2 translate-x-[-50%] w-full max-w-[34rem] 
+            flex flex-col items-center transition-all duration-300 bottom-[2rem]"
         >
           <CommonButton
             text="시작하기"

--- a/Loopy-fe/src/pages/Admin/Signin/_components/AdminSinginPage.tsx
+++ b/Loopy-fe/src/pages/Admin/Signin/_components/AdminSinginPage.tsx
@@ -5,7 +5,6 @@ import CommonHeader from "../../../../components/header/CommonHeader";
 import AdminAgreementDetailView from "./AdminAgreementDetailView";
 import AdminEmailVerifySection from "./sections/AdminEmailVerifySection";
 import AdminPasswordSection from "./sections/AdminPasswordSection";
-import AdminNicknameSection from "./sections/AdminNicknameSection";
 import AdminAgreementSection from "./sections/AdminAgreementSection";
 import type { FormData } from "../../../../types/form";
 import type { AgreementKey } from "../../../../types/agreement";
@@ -16,6 +15,13 @@ interface Props {
   onNext: () => void;
   onBack: () => void;
 }
+
+const AGREEMENT_TITLE_MAP: Record<AgreementKey, string> = {
+  terms: "서비스 이용 약관",
+  privacy: "개인정보 수집 및 이용 동의",
+  location: "위치기반 서비스 이용약관 동의",
+  marketing: "마케팅 정보 수신 동의",
+};
 
 const AdminSigninPage = ({ formData, setFormData, onNext, onBack }: Props) => {
   const isKeyboardOpen = useKeyboardOpen();
@@ -28,16 +34,15 @@ const AdminSigninPage = ({ formData, setFormData, onNext, onBack }: Props) => {
   const isValid =
     emailVerified &&
     passwordValid &&
-    !!formData.nickname &&
     formData.agreeTerms &&
     formData.agreePrivacy &&
     formData.agreelocation;
 
   if (agreementDetailKey) {
     return (
-      <div className="min-h-screen bg-white">
+      <div className="min-h-screen bg-white flex flex-col">
         <CommonHeader
-          title="회원가입"
+          title={AGREEMENT_TITLE_MAP[agreementDetailKey]}
           onBack={() => setAgreementDetailKey(null)}
         />
         <AdminAgreementDetailView agreementKey={agreementDetailKey} />
@@ -64,13 +69,6 @@ const AdminSigninPage = ({ formData, setFormData, onNext, onBack }: Props) => {
           onValidityChange={setPasswordValid}
         />
 
-        <AdminNicknameSection
-          value={formData.nickname}
-          onChange={(nickname) =>
-            setFormData((p) => ({ ...p, nickname }))
-          }
-        />
-
         <AdminAgreementSection
           agreeTerms={formData.agreeTerms}
           agreePrivacy={formData.agreePrivacy}
@@ -85,10 +83,10 @@ const AdminSigninPage = ({ formData, setFormData, onNext, onBack }: Props) => {
       <div
         className={`absolute left-1/2 translate-x-[-50%] w-full max-w-[34rem] flex flex-col items-center transition-all duration-300 ${
           isKeyboardOpen ? "bottom-[4rem]" : "bottom-[2rem]"
-          }`}
-        >
+        }`}
+      >
         <CommonButton
-          text="회원가입하기"
+          text="다음으로 넘어가기"
           onClick={onNext}
           disabled={!isValid}
           className={`w-full ${

--- a/Loopy-fe/src/pages/Admin/Signin/_components/sections/AdminAgreementSection.tsx
+++ b/Loopy-fe/src/pages/Admin/Signin/_components/sections/AdminAgreementSection.tsx
@@ -18,7 +18,7 @@ const AdminAgreementSection = ({
 }: Props) => {
   return (
     <>
-      <div className="h-[0.5px] w-full bg-[#DFDFDF] my-[0.5rem]" />
+      <div className="h-[0.5px] w-full bg-[#DFDFDF] my-[1.25rem]" />
 
       <AgreementItem
         label="서비스 이용약관"

--- a/Loopy-fe/src/pages/Admin/Signin/_components/sections/AdminPhoneSection.tsx
+++ b/Loopy-fe/src/pages/Admin/Signin/_components/sections/AdminPhoneSection.tsx
@@ -1,0 +1,23 @@
+import PhoneInput from "../AdminPhoneInput";
+
+interface Props {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const AdminPhoneSection = ({ value, onChange }: Props) => {
+  return (
+    <div className="mt-6">
+      <p className="mb-2 text-sm font-medium text-[#222222]">
+        전화번호
+      </p>
+
+      <PhoneInput
+        phone={value}
+        onChange={onChange}
+      />
+    </div>
+  );
+};
+
+export default AdminPhoneSection;

--- a/Loopy-fe/src/pages/Admin/Signin/index.tsx
+++ b/Loopy-fe/src/pages/Admin/Signin/index.tsx
@@ -5,9 +5,10 @@ import AdminSignupSuccess from "./_components/AdminSignupSuccess";
 import type { FormData } from "../../../types/form";
 import { useSignup } from "../../../hooks/mutation/signin/useSignup";
 import type { SignupRequest } from "../../../apis/auth/signin/type";
+import AdminProfilePage from "./_components/AdminProfilePage";
 
 const AdminSigninPageIndex = () => {
-  const [step, setStep] = useState<"account" | "success">("account");
+  const [step, setStep] = useState<"account" | "profile" | "success">("account");
   const navigate = useNavigate();
   const { mutate: signupMutate } = useSignup();
 
@@ -43,12 +44,8 @@ const AdminSigninPageIndex = () => {
     };
 
     signupMutate(payload, {
-      onSuccess: () => {
-        setStep("success");
-      },
-      onError: (err) => {
-        console.error("회원가입 실패:", err);
-      },
+      onSuccess: () => setStep("success"),
+      onError: (err) => console.error("회원가입 실패:", err),
     });
   };
 
@@ -58,14 +55,21 @@ const AdminSigninPageIndex = () => {
         <AdminSigninPage
           formData={formData}
           setFormData={setFormData}
-          onNext={handleSignup}
+          onNext={() => setStep("profile")}
           onBack={() => navigate("/admin")}
         />
       )}
 
-      {step === "success" && (
-        <AdminSignupSuccess />
+      {step === "profile" && (
+        <AdminProfilePage
+          formData={formData}
+          setFormData={setFormData}
+          onNext={handleSignup}
+          onBack={() => setStep("account")}
+        />
       )}
+
+      {step === "success" && <AdminSignupSuccess />}
     </div>
   );
 };


### PR DESCRIPTION
## 📌 변경사항
- 관리자 회원가입 플로우를 **step 기반 구조로 분리**하고, 회원가입 성공 화면을 추가했습니다.
- 이메일/비밀번호/약관 동의 → 프로필 입력 → 가입 완료로 이어지는 흐름을 명확히 구성했습니다.

## ℹ️ 관련 이슈
- closes #444

## ✅ 작업 내용 체크리스트
- [X] 회원가입 step 구조 분리 (account / profile / success)
- [X] 이메일 인증, 비밀번호 검증, 약관 동의 UI 정리
- [X] 닉네임·전화번호 입력 전용 step 추가
- [X] 회원가입 성공 화면 구현
- [X] 가입 완료 화면에서 뒤로가기 시 `/admin`으로 강제 이동 처리
- [X] POST 중복 요청 방지 구조 적용

## 📷 스크린샷 or 영상 (선택)
- 회원가입 step별 화면 스크린샷 첨부 예정

## 🧪 테스트 방법 (선택)
1. 관리자 회원가입 페이지(`/admin/sign`) 진입
2. 이메일 인증, 비밀번호 입력, 약관 동의 후 다음 단계 이동
3. 닉네임 및 전화번호 입력 후 회원가입 완료
4. 가입 완료 화면에서
   - `시작하기` 버튼 클릭 시 `/admin` 이동 확인
   - 브라우저 뒤로가기 시 `/admin`으로 강제 이동 확인
5. 새로고침 및 뒤로가기로 회원가입 POST가 재요청되지 않는 것 확인
