### PR TITLE
[Fix/#447] 스탬프 히스토리 완료일 적용

### DIFF
--- a/Loopy-fe/src/pages/User/My/StampHistory/_components/CompletedStampDetailPage.tsx
+++ b/Loopy-fe/src/pages/User/My/StampHistory/_components/CompletedStampDetailPage.tsx
@@ -1,5 +1,4 @@
-import { useState, useMemo } from "react";
-// import ArrowRight from "../../../../../assets/images/ArrowRight.svg?react";
+import { useMemo } from "react";
 import StampDetailLayout from "../../../../../layouts/StampDetailLayout";
 import type {
   ConvertedStampBookGroup,
@@ -13,21 +12,21 @@ interface Props {
 }
 
 const CompletedStampDetailPage = ({ history, onBack }: Props) => {
+  const currentItem: ConvertedStampBookItem | undefined = useMemo(() => {
+    return history.items
+      .slice()
+      .sort((a, b) => b.round - a.round)[0];
+  }, [history.items]);
+
   const latestConvertedAt = useMemo(() => {
-    const allDates = history.items.map((i) => i.convertedAt).filter(Boolean);
-    return allDates.length > 0 ? new Date(allDates.sort().reverse()[0]) : null;
-  }, [history]);
+    const allDates = history.items
+      .map((i) => i.convertedAt)
+      .filter(Boolean);
 
-  const rounds = useMemo(
-    () => history.items.map((i) => i.round), 
-    [history]
-  );
-
-  const [currentIndex, _setCurrentIndex] = useState(0);
-  const currentRound = rounds[currentIndex];
-  const currentItem: ConvertedStampBookItem | undefined = history.items.find(
-    (i) => i.round === currentRound
-  );
+    return allDates.length > 0
+      ? new Date(allDates.sort().reverse()[0])
+      : null;
+  }, [history.items]);
 
   const formatYMD = (d: string | Date | null | undefined) => {
     if (!d) return "-";
@@ -36,15 +35,18 @@ const CompletedStampDetailPage = ({ history, onBack }: Props) => {
     return `${year}.${month}.${day}`;
   };
 
-  // const handleNextRound = () => {
-  //   if (rounds.length <= 1) return; 
-  //   setCurrentIndex((prev) => (prev >= rounds.length - 1 ? 0 : prev + 1));
-  // };
+  if (!currentItem) {
+    return null;
+  }
+
+  const isExpired = currentItem.completedAt === null;
 
   return (
     <StampDetailLayout title="내 스탬프지" onBack={onBack}>
       <div className="flex items-center gap-2 mt-6 text-white font-semibold text-lg">
-        <span className="font-bold text-[1.125rem]">{history.cafeName}</span>
+        <span className="font-bold text-[1.125rem]">
+          {history.cafeName}
+        </span>
         {latestConvertedAt && (
           <span className="text-[#DFDFDF] text-[0.875rem] font-normal">
             ~{formatYMD(latestConvertedAt)}
@@ -53,34 +55,37 @@ const CompletedStampDetailPage = ({ history, onBack }: Props) => {
       </div>
 
       <div className="mt-1 text-[#E3F389] text-[1rem] font-semibold">
-        {currentItem?.displayText}
+        {currentItem.displayText}
       </div>
 
       <div className="relative bg-white rounded-t-xl mt-6 pt-6 pb-6 flex-grow -mx-[1.5rem] px-[1.5rem]">
-        <div className="text-[1rem] flex gap-[0.5rem] items-center mt-8" />
-
         <div className="my-20">
           <StampConvertedPaper currentStep={10} />
         </div>
 
         <div className="absolute inset-0 bg-black/70 z-110 rounded-t-xl" />
+
         <div className="absolute top-[1.5rem] left-0 w-full z-120 px-[1.5rem]">
-          <div className="relative w-full flex items-center">
-            <span className="text-[1.25rem] font-bold text-white mx-auto">
-              {currentRound}번째 스탬프지
-            </span>
-            {/* <ArrowRight
-              className="absolute right-0 w-[1.5rem] h-[1.5rem] text-white ml-auto cursor-pointer"
-              onClick={handleNextRound}
-            /> */}
-          </div>
+          <span className="block text-center text-[1.25rem] font-bold text-white">
+            {currentItem.round}번째 스탬프지
+          </span>
         </div>
 
-        <div className="absolute top-0 left-0 w-full h-full z-120 flex items-center justify-center px-[1.5rem] pointer-events-none">
+        <div className="absolute inset-0 z-120 flex items-center justify-center px-[1.5rem] pointer-events-none">
           <p className="text-white text-[1.125rem] font-bold text-center leading-[150%]">
-            {formatYMD(currentItem?.convertedAt)}에 스탬프를 모두 모았어요!
-            <br />
-            새로운 스탬프지를 채워보세요
+            {isExpired ? (
+              <>
+                {formatYMD(currentItem.convertedAt)}에 스탬프지가 만료됐어요
+                <br />
+                새로운 스탬프지를 채워보세요
+              </>
+            ) : (
+              <>
+                {formatYMD(currentItem.completedAt)}에 스탬프를 모두 모았어요!
+                <br />
+                새로운 스탬프지를 채워보세요
+              </>
+            )}
           </p>
         </div>
       </div>


### PR DESCRIPTION
## 📌 변경사항
- 완료/만료된 스탬프지 상세 화면 로직을 수정하여 **도메인 의미에 맞게 문구와 날짜 표시를 개선**했습니다.
- 스탬프지 상태(완료/만료)에 따라 **중앙 안내 문구를 분기 처리**하고, 만료일(`~YYYY.MM.DD`) 노출을 안전하게 처리했습니다.

## ℹ️ 관련 이슈
- closes #447

## ✅ 작업 내용 체크리스트
- [X] 완료/만료 스탬프지 전용 상세 페이지 로직 정리
- [X] round 기준 최신 스탬프지 선택 로직 적용
- [X] 완료(`completedAt`) / 만료(`convertedAt`) 상태에 따른 문구 분기 처리
- [X] 만료일(`convertedAt`)이 없는 경우 `~날짜` 미노출 처리
- [X] null 데이터 방어 처리로 UI 깨짐 방지

## 📷 스크린샷 or 영상 (선택)
- 완료된 스탬프지 상세 화면
- 만료된 스탬프지 상세 화면

## 🧪 테스트 방법 (선택)
1. 완료된 스탬프지가 있는 카페 히스토리 진입
   - 상단에 만료일(`~YYYY.MM.DD`) 표시 확인
   - 중앙 문구가 “OOO에 스탬프를 모두 모았어요!”로 표시되는지 확인
2. 만료된 스탬프지가 최신 round인 경우
   - 중앙 문구가 “OOO에 스탬프지가 만료됐어요”로 표시되는지 확인
3. `convertedAt`이 없는 데이터 케이스
   - 상단 `~날짜`가 렌더링되지 않는지 확인
4. 여러 round가 존재할 때
   - round가 가장 큰 스탬프지만 상세 화면에 노출되는지 확인
