### PR TITLE
[Fix/#451] 마이페이지 알림 수정

### DIFF
--- a/Loopy-fe/src/apis/my/alarm/api.ts
+++ b/Loopy-fe/src/apis/my/alarm/api.ts
@@ -1,87 +1,30 @@
 import axiosInstance from "../../axios";
-import type { NotificationListItem, MyNotificationListSuccess, NotificationDetail, NotificationDetailSuccess, NotificationType } from "./type";
+import type {
+  NotificationListItem,
+  NotificationDetail,
+  ApiSuccess,
+} from "./type";
 
-function buildMyNotificationsMock(): NotificationListItem[] {
-  const now = Date.now();
-  const mkDate = (minAgo: number) => new Date(now - minAgo * 60_000).toISOString();
+export async function getMyNotifications(): Promise<NotificationListItem[]> {
+  const url = `/api/v1/users/me/notification`;
 
-  const items: NotificationListItem[] = [
-    {
-      notificationId: 42,
-      cafeId: 3,
-      cafeName: "루피커피",
-      title: "스탬프 적립 조건이 변경됐어요!",
-      content: "8월 1일부터 스탬프는 5,000원 이상 결제 시 적립됩니다.",
-      type: "cafe" as NotificationType,
-      isRead: false,
-      createdAt: mkDate(10),
-    },
-    {
-      notificationId: 41,
-      cafeId: 2,
-      cafeName: "프렌즈라떼",
-      title: "쿠폰 만료 임박 안내",
-      content: { couponId: 99, expiresAt: mkDate(1440) }, 
-      type: "cafe",
-      isRead: true,
-      createdAt: mkDate(60 * 24 + 5),
-    },
-    {
-      notificationId: 40,
-      cafeId: 1,
-      cafeName: "모카마을",
-      title: "여름 한정 메뉴 출시",
-      content: "망고 라떼 출시! 이번 주만 20% 할인",
-      type: "cafe",
-      isRead: true,
-      createdAt: mkDate(60 * 24 * 3),
-    },
-  ];
+  const res = await axiosInstance.get<ApiSuccess<NotificationListItem[]>>(url);
 
-  return items.sort(
+  const list = res.data.success.data;
+
+  return [...list].sort(
     (a, b) => +new Date(b.createdAt) - +new Date(a.createdAt)
   );
 }
 
-export function buildNotificationMock(notificationId: number): NotificationDetail {
-  const cafes = [
-    { id: 1, name: "루피커피", address: "서울시 성북구 성북로 123" },
-    { id: 2, name: "프렌즈라떼", address: "서울시 관악구 대학길 45" },
-    { id: 3, name: "모카마을", address: "서울시 동작구 카페로 9" },
-  ];
-  const pick = cafes[(Math.abs(notificationId) || 1) % cafes.length];
-
-  return {
-    notificationId,
-    type: "cafe",
-    createdAt: new Date().toISOString(),
-    cafe: pick,
-  };
-}
-
-export async function getMyNotifications(): Promise<NotificationListItem[]> {
-  const url = `/api/v1/users/me/notification`;
-  try {
-    const res = await axiosInstance.get<MyNotificationListSuccess>(url);
-    const list = res.data?.data ?? [];
-    return [...list].sort(
-      (a, b) => +new Date(b.createdAt) - +new Date(a.createdAt)
-    );
-  } catch (err) {
-    console.warn("[getMyNotifications] 서버 실패로 목데이터 반환:", err);
-    return buildMyNotificationsMock();
-  }
-}
-
-export async function getNotificationDetail(notificationId: number): Promise<NotificationDetail> {
+export async function getNotificationDetail(
+  notificationId: number
+): Promise<NotificationDetail> {
   const url = `/api/v1/notification/${notificationId}`;
-  try {
-    const res = await axiosInstance.get<NotificationDetailSuccess>(url);
-    return res.data.data;
-  } catch (err) {
-    console.warn("[getNotificationDetail] 서버 실패로 목데이터 반환:", err);
-    return buildNotificationMock(notificationId);
-  }
+
+  const res = await axiosInstance.get<ApiSuccess<NotificationDetail>>(url);
+
+  return res.data.success.data;
 }
 
 export const MY_NOTIFICATIONS_QK = ["my", "notifications"] as const;

--- a/Loopy-fe/src/apis/my/alarm/type.ts
+++ b/Loopy-fe/src/apis/my/alarm/type.ts
@@ -1,3 +1,4 @@
+
 export type NotificationType = 'cafe' | (string & {});
 export type NotificationContent = string | Record<string, unknown>;
 
@@ -10,7 +11,7 @@ export interface CafeSummary {
 export interface NotificationListItem {
   notificationId: number;
   cafeId: number;
-  cafeName: string;
+  cafeName: string | null;
   title: string;
   content: NotificationContent;
   type: NotificationType;
@@ -25,14 +26,13 @@ export interface NotificationDetail {
   cafe: CafeSummary;
 }
 
-export interface MyNotificationListSuccess {
-  message: string;
-  data: NotificationListItem[];
-}
-
-export interface NotificationDetailSuccess {
-  message: string;
-  data: NotificationDetail;
+export interface ApiSuccess<T> {
+  resultType: "SUCCESS";
+  error: null;
+  success: {
+    message: string;
+    data: T;
+  };
 }
 
 export interface ApiErrorBody {

--- a/Loopy-fe/src/hooks/query/my/useMyPageNotifications.ts
+++ b/Loopy-fe/src/hooks/query/my/useMyPageNotifications.ts
@@ -10,7 +10,7 @@ import type {
   NotificationDetail,
 } from "../../../apis/my/alarm/type";
 
-export function useMyNotifications() {
+export function useMyPageNotifications() {
   return useQuery<NotificationListItem[]>({
     queryKey: MY_NOTIFICATIONS_QK,
     queryFn: getMyNotifications,

--- a/Loopy-fe/src/pages/User/My/CafeNotice/_components/MessageList.tsx
+++ b/Loopy-fe/src/pages/User/My/CafeNotice/_components/MessageList.tsx
@@ -1,9 +1,4 @@
-import { useEffect, useState } from "react";
 import MessageItem from "./MessageItem";
-import {
-  useOpenNotification,
-  useInvalidateMyNotifications,
-} from "../../../../../hooks/query/my/useMyNotifications";
 
 interface Message {
   id: number;
@@ -20,28 +15,13 @@ interface MessageListProps {
 }
 
 const MessageList = ({ messages, onOpen }: MessageListProps) => {
-  const [selectedId, setSelectedId] = useState<number | null>(null);
-
-  const { isSuccess } = useOpenNotification(selectedId ?? 0);
-  const invalidateList = useInvalidateMyNotifications();
-
-  useEffect(() => {
-    if (isSuccess) {
-      invalidateList();
-      setSelectedId(null);
-    }
-  }, [isSuccess, invalidateList]);
-
   return (
     <div className="flex flex-col gap-[0.5rem]">
       {messages.map((msg) => (
         <MessageItem
           key={msg.id}
           {...msg}
-          onOpen={() => {
-            setSelectedId(msg.id); 
-            onOpen(msg.id); 
-          }}
+          onOpen={() => onOpen(msg.id)}
         />
       ))}
     </div>

--- a/Loopy-fe/src/pages/User/My/CafeNotice/index.tsx
+++ b/Loopy-fe/src/pages/User/My/CafeNotice/index.tsx
@@ -2,10 +2,10 @@ import { useEffect, useState } from "react";
 import CommonHeader from "../../../../components/header/CommonHeader";
 import MessageList from "./_components/MessageList";
 import {
-  useMyNotifications,
+  useMyPageNotifications,
   useOpenNotification,
   useInvalidateMyNotifications,
-} from "../../../../hooks/query/my/useMyNotifications";
+} from "../../../../hooks/query/my/useMyPageNotifications";
 
 interface CafeNoticePageProps {
   onBack: () => void;
@@ -37,7 +37,7 @@ const isRecent7 = (iso: string) => {
 };
 
 const CafeNoticePage = ({ onBack }: CafeNoticePageProps) => {
-  const { data: notifications = [] } = useMyNotifications();
+  const { data: notifications = [] } = useMyPageNotifications();
   const invalidateList = useInvalidateMyNotifications();
   const [selectedId, setSelectedId] = useState<number | null>(null);
 
@@ -55,7 +55,7 @@ const CafeNoticePage = ({ onBack }: CafeNoticePageProps) => {
     const combined = n.title ? `${n.title}\n${content}` : content;
     return {
       id: n.notificationId,
-      sender: n.cafeName || "카페",
+      sender: n.cafeName || "알림",
       avatar: "",
       content: combined,
       date: fmt(n.createdAt),


### PR DESCRIPTION
## 📌 변경사항
- 마이페이지 카페 알림 목록 조회 및 읽음 처리 구조 개선
- 알림 API 응답 구조에 맞게 타입 및 파싱 로직 정리
- 알림 클릭 시 중복 쿼리 호출 제거 및 책임 분리
- cafeName이 없는 경우 발신자를 `카페 알림`으로 통일

## ℹ️ 관련 이슈
- closes #451 

## ✅ 작업 내용 체크리스트
- [X] 알림 API 타입 구조 정리 (ApiSuccess 래퍼 적용)
- [X] 알림 목록/상세 조회 API 파싱 로직 수정
- [X] 알림 읽음 처리 로직을 페이지 단에서만 관리하도록 구조 개선
- [X] MessageList 컴포넌트에서 서버 로직 제거 (UI 전용 컴포넌트화)
- [X] cafeName null 케이스 UX 개선 (`카페 알림` 표시)

## 📷 스크린샷 or 영상 (선택)
- 알림 목록 화면 (최근 7일 / 예전 메시지 구분)
- 알림 클릭 후 읽음 상태 반영 화면

## 🧪 테스트 방법 (선택)
1. 마이페이지 > 카페 알림 화면 진입
2. cafeName이 있는 알림과 없는 알림 모두 정상 표시되는지 확인
3. 알림 클릭 시 읽음 처리 후 UI 갱신 여부 확인
4. 새로고침 시 읽음 상태가 유지되는지 확인
