### PR TITLE
[Fix/#441] 지번 주소 수정

### DIFF
--- a/Loopy-fe/src/apis/admin/coupon/type.ts
+++ b/Loopy-fe/src/apis/admin/coupon/type.ts
@@ -5,8 +5,8 @@ export interface CreateOwnerCouponRequest {
   discountValue: number;           
   applicableMenuId?: number | null;  
   usageCondition?: string | null;   
-  startDate?: string;                 
-  endDate?: string;                    
+  startDate: string | null;
+  endDate: string | null;                    
   name?: string;                    
 }
 
@@ -19,10 +19,10 @@ export interface CreatedCoupon {
   applicableMenuId?: number | null;
   validDays?: number | null;
   isActive: boolean;
-  expiredAt?: string | null;     
+  expiredAt: string | null;     
   createdAt: string; 
-  startDate?: string;   
-  endDate?: string;
+  startDate: string | null;
+  endDate: string | null;
 }
 
 export interface CreateOwnerCouponResponse {
@@ -35,8 +35,8 @@ export interface OwnerCouponListItem {
   name: string;
   status: string;      
   usedCount: number;
-  startDate: string;    
-  endDate: string;         
+  startDate: string | null;
+  endDate: string | null;       
   discountType: DiscountType;
 }
 
@@ -44,12 +44,9 @@ export interface GetOwnerCouponsResponse {
   data: OwnerCouponListItem[];
 }
 
-export const toYmd = (iso: string) => {
-  try {
-    return new Date(iso).toISOString().slice(0, 10);
-  } catch {
-    return iso?.slice(0, 10) ?? '';
-  }
+export const toYmd = (iso?: string | null) => {
+  if (!iso) return '기한 없음';
+  return iso.slice(0, 10);
 };
 
 export interface TerminateOwnerCouponPathParams {

--- a/Loopy-fe/src/pages/Admin/Coupon/_components/AdminCouponListPage.tsx
+++ b/Loopy-fe/src/pages/Admin/Coupon/_components/AdminCouponListPage.tsx
@@ -35,7 +35,10 @@ const TYPE_LABEL: Record<CouponTypeKey, string> = {
   FREE_ITEM: '무료 음료',
 };
 
-const toYmdSafe = (iso?: string) => (iso ? iso.split('T')[0] : '');
+const toYmdSafe = (iso?: string | null): string | null => {
+  if (!iso) return null;
+  return iso.split('T')[0];
+};
 
 const mapToUICoupon = (item: OwnerCouponListItem) => {
   const hasPeriod = !!(item.startDate && item.endDate);
@@ -47,8 +50,8 @@ const mapToUICoupon = (item: OwnerCouponListItem) => {
     name: item.name,
     status: uiStatus,
     usage: item.usedCount,
-    startDate: hasPeriod ? toYmdSafe(item.startDate) : undefined,
-    endDate: hasPeriod ? toYmdSafe(item.endDate) : undefined,
+    startDate: hasPeriod ? toYmdSafe(item.startDate) : null,
+    endDate: hasPeriod ? toYmdSafe(item.endDate) : null,
     period: hasPeriod ? null : '제한 없음', 
     type: TYPE_LABEL[item.discountType as CouponTypeKey],
   };

--- a/Loopy-fe/src/pages/Admin/Coupon/_components/AdminCreateCouponPage.tsx
+++ b/Loopy-fe/src/pages/Admin/Coupon/_components/AdminCreateCouponPage.tsx
@@ -52,31 +52,24 @@ const AdminCouponCreatePage = ({ onBack, cafeId }: Props) => {
 
 
   const handleSubmit = () => {
-    if (!cafeId || !serverDiscountType) return;
+      if (!cafeId || !serverDiscountType) return;
 
-    const value = serverDiscountType === 'DISCOUNT' ? Number(discountAmount) || 0 : 0;
-    const usageCondition = hasCondition ? conditionText.trim() : undefined;
+      const value =
+        serverDiscountType === 'DISCOUNT' ? Number(discountAmount) || 0 : 0;
 
-    const base = {
-      discountType: serverDiscountType,
-      discountValue: value,
-      applicableMenuId: selectedMenuId ?? undefined,
-      usageCondition,
-    } as const;
+      const usageCondition = hasCondition ? conditionText.trim() : undefined;
 
-    const payload: CreateOwnerCouponRequest =
-      hasLimit && startDate && endDate
-        ? {
-            ...base,
-            startDate: startDate.toISOString(),
-            endDate: endDate.toISOString(),
-          }
-        : {
-            ...base,
-          };
+      const payload: CreateOwnerCouponRequest = {
+        discountType: serverDiscountType,
+        discountValue: value,
+        applicableMenuId: selectedMenuId ?? undefined,
+        usageCondition,
+        startDate: hasLimit ? startDate?.toISOString() ?? null : null,
+        endDate: hasLimit ? endDate?.toISOString() ?? null : null,
+      };
 
-    createCoupon({ cafeId, payload });
-  };
+      createCoupon({ cafeId, payload });
+    };
 
   return (
     <div className="flex flex-col w-full">

--- a/Loopy-fe/src/pages/Admin/Coupon/_components/DateRangePicker.tsx
+++ b/Loopy-fe/src/pages/Admin/Coupon/_components/DateRangePicker.tsx
@@ -10,6 +10,14 @@ interface Props {
   onChangeEndDate: (date: Date | null) => void;
 }
 
+// 날짜를 로컬 기준 00:00으로 고정
+const normalizeDate = (date: Date | null) => {
+  if (!date) return null;
+  const d = new Date(date);
+  d.setHours(12, 0, 0, 0);
+  return d;
+};
+
 const DateRangePicker = ({
   startDate,
   endDate,
@@ -19,7 +27,8 @@ const DateRangePicker = ({
   const format = (date: Date | null) =>
     date ? dayjs(date).format('YYYY.MM.DD') : '';
 
-  const isError = startDate && endDate && dayjs(endDate).isBefore(startDate, 'day');
+  const isError =
+    startDate && endDate && dayjs(endDate).isBefore(startDate, 'day');
 
   return (
     <>
@@ -27,7 +36,7 @@ const DateRangePicker = ({
         <div className="relative w-full border-none">
           <DatePicker
             selected={startDate}
-            onChange={(date) => onChangeStartDate(date)}
+            onChange={(date) => onChangeStartDate(normalizeDate(date))}
             dateFormat="yyyy.MM.dd"
             maxDate={endDate ?? undefined}
             customInput={
@@ -44,11 +53,13 @@ const DateRangePicker = ({
             }
           />
         </div>
+
         <span>~</span>
+
         <div className="relative w-full border-none">
           <DatePicker
             selected={endDate}
-            onChange={(date) => onChangeEndDate(date)}
+            onChange={(date) => onChangeEndDate(normalizeDate(date))}
             dateFormat="yyyy.MM.dd"
             minDate={startDate ?? undefined}
             customInput={

--- a/Loopy-fe/src/pages/Admin/Setting/_components/tabList/basic/AddressSearchField.tsx
+++ b/Loopy-fe/src/pages/Admin/Setting/_components/tabList/basic/AddressSearchField.tsx
@@ -30,10 +30,13 @@ const AddressSearchField = ({
   const [isRegionModalOpen, setIsRegionModalOpen] = useState(false);
   const [isRoadModalOpen, setIsRoadModalOpen] = useState(false);
 
+  const [_picked, setPicked] = useState<PickedAddress>({});
+
   const updatePicked = (patch: Partial<PickedAddress>) => {
-    onPick?.({
-      ...(typeof onPick === "function" ? {} : {}), 
-      ...patch,
+    setPicked(prev => {
+      const next = { ...prev, ...patch };
+      onPick?.(next);
+      return next;
     });
   };
 

--- a/Loopy-fe/src/pages/Admin/Setting/_components/tabList/basic/BasicInfoFormView.tsx
+++ b/Loopy-fe/src/pages/Admin/Setting/_components/tabList/basic/BasicInfoFormView.tsx
@@ -83,7 +83,7 @@ const BasicInfoFormView = ({
           if (picked.region1DepthName) setField("region1DepthName")(picked.region1DepthName);
           if (picked.region2DepthName) setField("region2DepthName")(picked.region2DepthName);
           if (picked.region3DepthName) setField("region3DepthName")(picked.region3DepthName);
-          if (picked.roadAddress) setField("address")(picked.roadAddress);
+          if (picked.jibunAddress) setField("address")(picked.jibunAddress);
           if (picked.latitude) setField("latitude")(picked.latitude);
           if (picked.longitude) setField("longitude")(picked.longitude);
         }}

--- a/Loopy-fe/src/pages/Admin/Setting/_components/tabList/basic/ModalRoadAddressSelector.tsx
+++ b/Loopy-fe/src/pages/Admin/Setting/_components/tabList/basic/ModalRoadAddressSelector.tsx
@@ -23,14 +23,14 @@ export default function ModalRoadAddressSelector({
     isLoading,
   } = useJibunAddressSearch();
 
-  // ✅ 지번 주소에 숫자가 포함되어 있는지 (번지 여부)
+  // 지번 주소에 숫자가 포함되어 있는지 (번지 여부)
   const hasDetailAddress =
     !!selected && /\d/.test(selected.jibunAddress);
 
   const handleConfirm = () => {
     if (!selected) return;
 
-    // ❌ 시·구·동까지만 있는 지번 주소는 확정 불가
+    // 시·구·동까지만 있는 지번 주소는 확정 불가
     if (!/\d/.test(selected.jibunAddress)) {
       return;
     }

--- a/Loopy-fe/src/pages/User/My/CouponBox/_components/CouponCard.tsx
+++ b/Loopy-fe/src/pages/User/My/CouponBox/_components/CouponCard.tsx
@@ -5,13 +5,18 @@ import CouponIcon from "../../../../../assets/images/Coupon.svg?react";
 interface CouponCardProps {
   coupon: UserCoupon;
   isPast: boolean;
-  showCafeHeader?: boolean; 
+  showCafeHeader?: boolean;
 }
 
-const fmt = (iso: string) =>
-  new Date(iso).toISOString().slice(0, 10).replaceAll("-", ".");
+const fmt = (iso?: string | null) => {
+  if (!iso) return null;
+  return new Date(iso).toISOString().slice(0, 10).replaceAll("-", ".");
+};
 
 const CouponCard = ({ coupon, isPast, showCafeHeader = true }: CouponCardProps) => {
+  const start = fmt(coupon.couponTemplate.startDate);
+  const end = fmt(coupon.couponTemplate.endDate);
+
   return (
     <CommonCard padding="p-0" className="flex items-center justify-between">
       <div className="flex items-center">
@@ -38,8 +43,9 @@ const CouponCard = ({ coupon, isPast, showCafeHeader = true }: CouponCardProps) 
               <span className="text-[1rem] text-[#171718] font-semibold mb-2">
                 {coupon.couponTemplate.name}
               </span>
+
               <span className="text-[0.875rem] text-[#7F7F7F]">
-                {fmt(coupon.couponTemplate.startDate)} ~ {fmt(coupon.couponTemplate.endDate)}
+                {start && end ? `${start} ~ ${end}` : "기한 없음"}
               </span>
             </div>
           </>


### PR DESCRIPTION
## 📌 변경사항
- 주소 입력 플로우에서 **지번 주소가 도로명으로 덮어써지던 문제를 수정**
- 지번 주소 선택 시 화면 표시 및 폼 상태에 **지번 주소만 유지**되도록 개선

## ℹ️ 관련 이슈
- closes #441 

## ✅ 작업 내용 체크리스트
- [X] 지번 주소 선택 후 도로명으로 덮어써지던 로직 제거
- [X] 지번 주소(`jibunAddress`)를 단일 소스로 사용하도록 상태 업데이트
- [X] AddressSearchField / BasicInfoFormView 간 주소 처리 흐름 정리

## 📷 스크린샷 or 영상 (선택)
- 지번 주소 선택 후 화면에 정상적으로 지번 주소가 표시되는 화면

## 🧪 테스트 방법 (선택)
1. 주소 검색 → 지번 주소 선택
2. 기본 정보 입력 화면에서 주소 필드 확인
3. 페이지 이동/리렌더링 이후에도 주소가 **지번으로 유지되는지** 확인
