### PR TITLE
[Fix/#449] 쿠폰 기한 문구 수정

### DIFF
--- a/Loopy-fe/src/pages/User/Detail/_components/CouponModal.tsx
+++ b/Loopy-fe/src/pages/User/Detail/_components/CouponModal.tsx
@@ -42,7 +42,10 @@ export default function CouponReceivedModal({ onClose, coupon }: Props) {
 
       {/* 기간 */}
       <p className="mt-[1rem] text-[#7F7F7F] text-[0.875rem] font-normal leading-[1.5rem]">
-        쿠폰 기한은 {formatDate(coupon.createdAt)} ~ {formatDate(coupon.expiredAt)}이며,
+        {coupon.expiredAt
+          ? `쿠폰 기한은 ${formatDate(coupon.createdAt)}~${formatDate(coupon.expiredAt)}이며,`
+          : '쿠폰 기한은 없으며,'  
+        }
         {coupon.usageCondition
           ? ` 해당 쿠폰은 ${coupon.usageCondition}에만 사용 가능해요`
           : ' 해당 쿠폰은 사용 조건 없이 사용 가능해요'}


### PR DESCRIPTION
## 📌 변경사항
- 쿠폰 기한 없을 때 문구 수정
<img width="630" height="482" alt="image" src="https://github.com/user-attachments/assets/156ffa6b-074b-4a6b-9db5-5722bbc67b1c" />

## ℹ️ 관련 이슈
- closes #449 

