### PR TITLE
[Chore/#468] 가게등록 운영 관리 페이지 수정

### DIFF
--- a/Loopy-fe/src/pages/Admin/Register/_components/SelectableDayButton.tsx
+++ b/Loopy-fe/src/pages/Admin/Register/_components/SelectableDayButton.tsx
@@ -1,34 +1,47 @@
 type DayState = 'active' | 'filled' | 'empty';
 
 interface SelectableDayButtonProps {
-    label: string;
-    selected?: boolean;
-    onClick: () => void;
-    state?: DayState;
+  label: string;
+  selected?: boolean;
+  onClick: () => void;
+  state?: DayState;
+  disabled?: boolean;
 }
 
 export default function SelectableDayButton({
-    label,
-    onClick,
-    state,
-    selected,
+  label,
+  onClick,
+  state,
+  selected,
+  disabled = false,
 }: SelectableDayButtonProps) {
-    const resolved: DayState =
+  const resolved: DayState =
     state ?? (selected ? 'filled' : 'empty');
 
-    const base =
-        'rounded-[0.25rem] text-[0.875rem] leading-[100%] px-[0.75rem] py-[0.625rem] transition-colors';
-    const borderFix = { borderWidth: '0.03125rem' as const }; // 0.5px = 0.03125rem
+  const base =
+    'rounded-[0.25rem] text-[0.875rem] leading-[100%] px-[0.75rem] py-[0.625rem] transition-colors';
 
-    const styles: Record<DayState, string> = {
-        active: 'bg-[#6970F3] text-white border border-[#6970F3]',
-        filled: 'bg-[#F0F1FE] text-[#6970F3] border border-[#6970F3]',
-        empty:  'bg-white text-[#252525] border border-[#A8A8A8]',
-    };
+  const borderFix = { borderWidth: '0.03125rem' as const }; 
 
-    return (
-        <button type="button" onClick={onClick} className={`${base} ${styles[resolved]}`} style={borderFix}>
-            {label}
-        </button>
-    );
+  const styles: Record<DayState, string> = {
+    active: 'bg-[#6970F3] text-white border border-[#6970F3]',
+    filled: 'bg-[#F0F1FE] text-[#6970F3] border border-[#6970F3]',
+    empty:  'bg-white text-[#252525] border border-[#A5A5A5]',
+  };
+
+  const disabledStyle =
+    'bg-white text-[#000000] border border-[#A5A5A5]';
+
+  return (
+    <button
+      type="button"
+      onClick={onClick} 
+      className={`${base} ${
+        disabled ? disabledStyle : styles[resolved]
+      }`}
+      style={borderFix}
+    >
+      {label}
+    </button>
+  );
 }

--- a/Loopy-fe/src/pages/Admin/Register/_steps/Step3BusinessInfo.tsx
+++ b/Loopy-fe/src/pages/Admin/Register/_steps/Step3BusinessInfo.tsx
@@ -1,12 +1,11 @@
 import { useState } from "react";
-import SelectableDayButton from "../_components/SelectableDayButton";
+import DaySelector, { type Day } from "../../Setting/_components/tabList/operation/DaySelector";
 import KeywordSelector from "../_components/KeywordSelector";
 import BasicInput from "../_components/BasicInput";
 import AddButton from "../_components/AddButton";
 import RemovableKeywordTags from "../_components/RemovableKeywordTags";
 import TimeSection from "../_components/TimeSection";
 import type { TimeSectionValues } from "../_components/TimeSection";
-import SelectableItem from "../_components/SelectableItem";
 import CommonButton from "../../../../components/button/CommonButton";
 import { useUpdateOwnerCafeOperation } from "../../../../hooks/mutation/admin/patch/useUpdateOperation";
 import type {
@@ -14,11 +13,10 @@ import type {
   BusinessHour,
 } from "../../../../apis/admin/register/operation/type";
 
-const weekDays = ["월", "화", "수", "목", "금", "토", "일"] as const;
-type WeekDay = typeof weekDays[number];
+const weekDays: Day[] = ["월", "화", "수", "목", "금", "토", "일"];
 
 const dayMap: Record<
-  WeekDay,
+  Day,
   UpdateOwnerCafeOperationPayload["businessHours"][number]["day"]
 > = {
   월: "MONDAY",
@@ -35,47 +33,30 @@ interface Step3BusinessInfoProps {
 }
 
 export default function Step3BusinessInfo({ onNext }: Step3BusinessInfoProps) {
-  const [noHolidays, setNoHolidays] = useState(false);
-  const [closedDays, setClosedDays] = useState<WeekDay[]>([]);
+  const [selectedDays, setSelectedDays] = useState<Day[]>([]);
+  const [dayTouched, setDayTouched] = useState(false);
 
-  const toggleNoHolidays = () => {
-    if (noHolidays) {
-      setNoHolidays(false);
-      setClosedDays([]);
-    } else {
-      setNoHolidays(true);
-      setClosedDays([...weekDays]);
-    }
-  };
-
-  const toggleClosedDay = (day: WeekDay) => {
-    setClosedDays((prev) => {
-      let newDays: WeekDay[];
-
-      if (prev.includes(day)) {
-        newDays = prev.filter((d) => d !== day);
-        setNoHolidays(false);
-      } else {
-        newDays = [...prev, day];
-      }
-
-      if (newDays.length === weekDays.length) {
-        setNoHolidays(true);
-      }
-
-      return newDays;
-    });
-  };
-
+  const isDayValid = selectedDays.length > 0;
   const [timeValues, setTimeValues] = useState<TimeSectionValues>({
     type: "" as "" | "all" | "weekdayWeekend" | "byDay",
     all: { open: "", close: "", breakType: "없음", breakStart: "", breakEnd: "" },
-    weekday: { open: "", close: "", breakType: "없음", breakStart: "", breakEnd: "" },
-    weekend: { open: "", close: "", breakType: "없음", breakStart: "", breakEnd: "" },
+    weekday: {
+      open: "",
+      close: "",
+      breakType: "없음",
+      breakStart: "",
+      breakEnd: "",
+    },
+    weekend: {
+      open: "",
+      close: "",
+      breakType: "없음",
+      breakStart: "",
+      breakEnd: "",
+    },
     byDay: {},
   });
 
-  // 대표 해시태그
   const [hashtagInput, setHashtagInput] = useState("");
   const [hashtags, setHashtags] = useState<string[]>([]);
 
@@ -86,7 +67,6 @@ export default function Step3BusinessInfo({ onNext }: Step3BusinessInfoProps) {
     }
   };
 
-  // 키워드 필터 (3개 분리)
   const [storeFilters, setStoreFilters] = useState<string[]>([]);
   const [takeOutFilters, setTakeOutFilters] = useState<string[]>([]);
   const [menuFilters, setMenuFilters] = useState<string[]>([]);
@@ -102,8 +82,7 @@ export default function Step3BusinessInfo({ onNext }: Step3BusinessInfoProps) {
   });
 
   const isFormValid =
-    hashtags.length >= 0 &&
-    (noHolidays || closedDays.length > 0) &&
+    isDayValid &&
     (timeValues.type === "all"
       ? timeValues.all.open && timeValues.all.close
       : timeValues.type === "weekdayWeekend"
@@ -112,14 +91,17 @@ export default function Step3BusinessInfo({ onNext }: Step3BusinessInfoProps) {
         timeValues.weekend.open &&
         timeValues.weekend.close
       : weekDays.every((day) => {
-          if (closedDays.includes(day)) return true;
-          const t = timeValues.byDay[day as WeekDay];
+          if (!selectedDays.includes(day)) return true;
+          const t = timeValues.byDay[day];
           return t?.open && t?.close;
         }));
 
   const handleSubmit = () => {
+    setDayTouched(true);
+    if (!isDayValid) return;
+
     const businessHours: BusinessHour[] = weekDays.map((day) => {
-      const isClosed = closedDays.includes(day);
+      const isClosed = !selectedDays.includes(day);
 
       const times =
         timeValues.type === "all"
@@ -128,7 +110,7 @@ export default function Step3BusinessInfo({ onNext }: Step3BusinessInfoProps) {
           ? ["토", "일"].includes(day)
             ? timeValues.weekend
             : timeValues.weekday
-          : timeValues.byDay[day as WeekDay] || {
+          : timeValues.byDay[day] || {
               open: "",
               close: "",
               breakType: "없음",
@@ -139,10 +121,12 @@ export default function Step3BusinessInfo({ onNext }: Step3BusinessInfoProps) {
       return {
         day: dayMap[day],
         isClosed,
-        openTime: times.open || "",
-        closeTime: times.close || "",
-        breakStart: times.breakType !== "없음" ? times.breakStart || "" : "",
-        breakEnd: times.breakType !== "없음" ? times.breakEnd || "" : "",
+        openTime: isClosed ? "" : times.open,
+        closeTime: isClosed ? "" : times.close,
+        breakStart:
+          !isClosed && times.breakType !== "없음" ? times.breakStart || "" : "",
+        breakEnd:
+          !isClosed && times.breakType !== "없음" ? times.breakEnd || "" : "",
       };
     });
 
@@ -177,45 +161,27 @@ export default function Step3BusinessInfo({ onNext }: Step3BusinessInfoProps) {
             우리 매장의 운영정보를 입력해주세요
           </h1>
 
-          {/* 운영일 */}
-          <div className="mt-[0.5rem]">
-            <div className="text-[1rem] font-semibold leading-[100%]">운영일</div>
-            <div className="flex flex-col mt-[1rem]">
-              <div role="button" tabIndex={0} onClick={toggleNoHolidays}>
-                <SelectableItem
-                  label="휴무일이 없어요"
-                  selected={noHolidays}
-                  onClick={toggleNoHolidays}
-                />
-              </div>
-              <div className="flex gap-[0.5rem] flex-wrap mt-[1rem]">
-                {weekDays.map((day) => (
-                  <SelectableDayButton
-                    key={day}
-                    label={day}
-                    selected={closedDays.includes(day)}
-                    onClick={() => toggleClosedDay(day)}
-                  />
-                ))}
-              </div>
-            </div>
-          </div>
+          <DaySelector
+            selectedDays={selectedDays}
+            setSelectedDays={(days) => {
+              setSelectedDays(days);
+              setDayTouched(true);
+            }}
+            showError={dayTouched}
+          />
 
-          {/* 영업시간 */}
-          <div>
-            <TimeSection values={timeValues} setValues={setTimeValues} />
-          </div>
+          <TimeSection values={timeValues} setValues={setTimeValues} />
 
-          {/* 대표 해시태그 */}
           <div>
-            <div className="text-[1rem] font-semibold mb-[0.5rem] leading-[100%]">
+            <div className="text-[1rem] font-semibold mb-[0.5rem]">
               대표 해시태그
             </div>
-            <p className="text-[0.875rem] text-[#7F7F7F] mb-[0.75rem] leading-[100%]">
+
+            <p className="text-[0.875rem] text-[#7F7F7F] mb-[0.75rem]">
               해시태그는 최대 2개까지 가능해요 (예시: 말차 맛집)
             </p>
 
-            <div className="flex flex-1 items-center gap-[0.5rem] mb-[0.75rem] shrink-0">
+            <div className="flex items-center gap-[0.5rem] mb-[0.75rem]">
               <BasicInput
                 placeholder="대표 해시태그를 입력해주세요"
                 value={hashtagInput}
@@ -227,7 +193,7 @@ export default function Step3BusinessInfo({ onNext }: Step3BusinessInfoProps) {
                 text="추가하기"
                 onClick={handleAddHashtag}
                 disabled={hashtags.length >= 2}
-                className={`text-white min-w-[5.5rem] whitespace-nowrap px-[1rem] py-[0.75rem] ${
+                className={`text-white min-w-[5.5rem] px-[1rem] py-[0.75rem] ${
                   hashtags.length >= 2
                     ? "bg-[#CCCCCC] text-[#7F7F7F] pointer-events-none"
                     : ""
@@ -238,13 +204,17 @@ export default function Step3BusinessInfo({ onNext }: Step3BusinessInfoProps) {
             {hashtags.length > 0 && (
               <RemovableKeywordTags
                 keywords={hashtags}
-                onRemove={(tag) => setHashtags((prev) => prev.filter((t) => t !== tag))}
+                onRemove={(tag) =>
+                  setHashtags((prev) => prev.filter((t) => t !== tag))
+                }
               />
             )}
           </div>
 
           <div>
-            <div className="text-[1rem] font-semibold mb-[0.75rem]">카페 키워드</div>
+            <div className="text-[1rem] font-semibold mb-[0.75rem]">
+              카페 키워드
+            </div>
             <KeywordSelector
               storeFilters={storeFilters}
               setStoreFilters={setStoreFilters}
@@ -257,7 +227,7 @@ export default function Step3BusinessInfo({ onNext }: Step3BusinessInfoProps) {
         </div>
       </div>
 
-      <div className="fixed bottom-0 left-1/2 -translate-x-1/2 w-full px-[1.5rem] pt-[1rem] pb-[2rem] max-w-[1024px] flex justify-center bg-white">
+      <div className="fixed bottom-0 left-1/2 -translate-x-1/2 w-full px-[1.5rem] pt-[1rem] pb-[2rem] max-w-[1024px] bg-white flex justify-center">
         <CommonButton
           text="다음으로 넘어가기"
           onClick={handleSubmit}

--- a/Loopy-fe/src/pages/Admin/Register/_steps/Step5Stamp.tsx
+++ b/Loopy-fe/src/pages/Admin/Register/_steps/Step5Stamp.tsx
@@ -297,7 +297,7 @@ export default function Step5Stamp({ setValid }: Step5StampProps) {
         <button
           onClick={handleSubmit}
           disabled={!valid}
-          className="bg-[#6970F3] text-[#7F7F7F] py-[0.75rem] rounded-lg font-semibold disabled:bg-[#DFDFDF]"
+          className="bg-[#6970F3] text-white py-[0.75rem] rounded-lg font-semibold disabled:bg-[#DFDFDF] disabled:text-[#7F7F7F]"
         >
           다음으로 넘어가기
         </button>

--- a/Loopy-fe/src/pages/Admin/Setting/_components/tabList/OperationInfoTab.tsx
+++ b/Loopy-fe/src/pages/Admin/Setting/_components/tabList/OperationInfoTab.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import CommonAdminButton from "../../../../../components/admin/button/CommonAdminButton";
 import DaySelector from "./operation/DaySelector";
 import TimeSection from "./operation/TimeSection";
@@ -7,15 +8,39 @@ import { useOwnerOperationForm } from "./operation/_logic/useOwnerOperationForm"
 
 const OperationInfoTab = () => {
   const {
-    selectedDays, setSelectedDays,
-    hashtags, setHashtags,
-    storeFilters, setStoreFilters,
-    takeOutFilters, setTakeOutFilters,
-    menuFilters, setMenuFilters,
-    timeSectionValues, setTimeSectionValues,
-    isLoading, isError, setIsFormValid,
-    isFormValid, submitLabel, submit,
+    selectedDays,
+    setSelectedDays,
+    hashtags,
+    setHashtags,
+    storeFilters,
+    setStoreFilters,
+    takeOutFilters,
+    setTakeOutFilters,
+    menuFilters,
+    setMenuFilters,
+    timeSectionValues,
+    setTimeSectionValues,
+    isLoading,
+    isError,
+    setIsFormValid,
+    isFormValid,
+    submitLabel,
+    submit,
   } = useOwnerOperationForm();
+
+  const [dayTouched, setDayTouched] = useState(false);
+  const [isDirty, setIsDirty] = useState(false);
+  const isDayValid = selectedDays.length > 0;
+
+  useEffect(() => {
+    setIsFormValid(isDayValid);
+  }, [isDayValid, setIsFormValid]);
+
+  const handleSubmit = async () => {
+    await submit();       
+    setIsDirty(false);  
+    setDayTouched(false); 
+  };
 
   if (isLoading) {
     return (
@@ -38,33 +63,58 @@ const OperationInfoTab = () => {
       <div className="font-bold text-[1.25rem] mb-10">
         우리 매장의 운영정보를 입력해주세요
       </div>
+
       <div className="flex flex-col gap-12">
-        <DaySelector 
-          selectedDays={selectedDays} 
-          setSelectedDays={setSelectedDays} 
+        <DaySelector
+          selectedDays={selectedDays}
+          setSelectedDays={(days) => {
+            setDayTouched(true);
+            setIsDirty(true);
+            setSelectedDays(days);
+          }}
+          showError={dayTouched && !isDayValid}
         />
-        <TimeSection 
-          values={timeSectionValues} 
-          setValues={setTimeSectionValues} 
-          selectedDays={selectedDays} 
-          setValid={setIsFormValid} 
+
+        <TimeSection
+          values={timeSectionValues}
+          setValues={(v) => {
+            setIsDirty(true);
+            setTimeSectionValues(v);
+          }}
+          selectedDays={selectedDays}
+          setValid={setIsFormValid}
         />
-        <CafeHashtagInput 
-          hashtags={hashtags} 
-          setHashtags={setHashtags} 
+
+        <CafeHashtagInput
+          hashtags={hashtags}
+          setHashtags={(v) => {
+            setIsDirty(true);
+            setHashtags(v);
+          }}
         />
-        <CafeKeywordSection 
-          storeFilters={storeFilters} 
-          setStoreFilters={setStoreFilters}
-          takeOutFilters={takeOutFilters} 
-          setTakeOutFilters={setTakeOutFilters}
-          menuFilters={menuFilters} 
-          setMenuFilters={setMenuFilters}
+
+        <CafeKeywordSection
+          storeFilters={storeFilters}
+          setStoreFilters={(v) => {
+            setIsDirty(true);
+            setStoreFilters(v);
+          }}
+          takeOutFilters={takeOutFilters}
+          setTakeOutFilters={(v) => {
+            setIsDirty(true);
+            setTakeOutFilters(v);
+          }}
+          menuFilters={menuFilters}
+          setMenuFilters={(v) => {
+            setIsDirty(true);
+            setMenuFilters(v);
+          }}
         />
-        <CommonAdminButton 
-          label={submitLabel} 
-          disabled={!isFormValid} 
-          onClick={submit}
+
+        <CommonAdminButton
+          label={submitLabel}
+          disabled={!isFormValid || !isDayValid || !isDirty}
+          onClick={handleSubmit}
         />
       </div>
     </div>

--- a/Loopy-fe/src/pages/Admin/Setting/_components/tabList/operation/DaySelector.tsx
+++ b/Loopy-fe/src/pages/Admin/Setting/_components/tabList/operation/DaySelector.tsx
@@ -6,26 +6,28 @@ const week: Day[] = ["월", "화", "수", "목", "금", "토", "일"];
 const DaySelector = ({
   selectedDays,
   setSelectedDays,
+  showError,
 }: {
   selectedDays: Day[];
   setSelectedDays: (days: Day[]) => void;
+  showError: boolean;
 }) => {
   const allSelected = selectedDays.length === week.length;
 
   const handleNoHolidayToggle = () => {
-    if (allSelected) setSelectedDays([]);   
-    else setSelectedDays(week);
+    setSelectedDays(allSelected ? [] : week);
   };
 
   return (
     <div>
       <div className="font-semibold text-[1rem] mb-4">운영일</div>
+
       <button
         type="button"
         className="flex items-center mb-4"
         onClick={handleNoHolidayToggle}
       >
-        <CheckCircle checked={allSelected}/>
+        <CheckCircle checked={allSelected} />
         <span
           className={`ml-2 text-[1rem] font-medium transition
             ${allSelected ? "text-[#6970F3]" : "text-black"}`}
@@ -41,25 +43,32 @@ const DaySelector = ({
             <button
               key={day}
               type="button"
-              onClick={() => {
+              onClick={() =>
                 setSelectedDays(
                   checked
                     ? selectedDays.filter((d) => d !== day)
                     : [...selectedDays, day]
-                );
-              }}
-              className={`px-[0.75rem] py-[0.5rem] flex items-center justify-center rounded-[4px] border outline-none
-                text-[0.875rem] font-medium
-                ${checked
-                  ? "text-[#6970F3] bg-[#F0F1FE] border-[#6970F3]"
-                  : "text-[#0F0F0F] border-[#A5A5A5]"} 
-                transition`}
+                )
+              }
+              className={`px-[0.75rem] py-[0.5rem] rounded-[4px] border
+                text-[0.875rem] font-medium transition
+                ${
+                  checked
+                    ? "text-[#6970F3] bg-[#F0F1FE] border-[#6970F3]"
+                    : "text-[#0F0F0F] border-[#A5A5A5]"
+                }`}
             >
               {day}
             </button>
           );
         })}
       </div>
+
+      {showError && selectedDays.length === 0 && (
+        <div className="mt-2 text-[0.75rem] text-[#FF1E1E]">
+          최소 하루 이상 운영일을 선택해 주세요
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## 📌 변경사항
- 운영일 선택 로직을 **기존 복잡한 휴무일/비활성화 구조에서 DaySelector 기반 단일 상태 구조로 리팩토링**했습니다.
- ‘휴무일이 없어요’ 토글과 요일 개별 선택을 **하나의 selectedDays 상태로 통합**하여,
  - 모든 요일 선택 / 해제
  - 개별 요일 선택/해제
  - 최소 1일 이상 선택 유효성 검사
  를 일관되게 처리하도록 개선했습니다.
- 운영일 미선택 시에만 에러 메시지가 노출되고, **하나라도 선택되면 즉시 에러가 해제**되도록 UX를 정교화했습니다.

## ℹ️ 관련 이슈
- closes #468 

## ✅ 작업 내용 체크리스트
- [X] 운영일 선택 UI 리팩토링 (DaySelector 적용)
- [X] 휴무일 관련 상태(noHolidays, closedDays) 제거
- [X] 운영일 선택 유효성 로직 단순화 및 안정화
- [X] 기존 디자인/스타일 변경 없이 로직만 수정
- [X] 운영시간(TimeSection) 및 제출 로직과 정상 연동 확인

## 📷 스크린샷 or 영상 (선택)

## 🧪 테스트 방법 (선택)
1. Step3 운영정보 화면 진입
2. 운영일을 하나도 선택하지 않은 상태에서 다음 버튼 클릭 → 에러 메시지 노출 확인
3. 요일 1개 이상 선택 → 에러 메시지 즉시 해제 확인
4. ‘휴무일이 없어요’ 클릭 → 7일 전체 선택 확인
5. 전체 선택 상태에서 요일 개별 해제/선택 정상 동작 확인
6. 운영시간 입력 후 다음 버튼 클릭 → 정상 제출 확인
