### PR TITLE
[Refactor/#475] 카카오 계정 병합 시 JWT 갱신 처리

### DIFF
--- a/Loopy-fe/src/apis/auth/verifyPhone/patch/type.ts
+++ b/Loopy-fe/src/apis/auth/verifyPhone/patch/type.ts
@@ -3,10 +3,13 @@ export interface SavePhoneRequest {
 }
 
 export interface SavePhoneResponse {
-  message: string; 
-  userId: string;  
-  phoneNumber: string; 
+  message: string;
+  merged: boolean;
+  userId: string;
+  phoneNumber: string;
+  token?: string; 
 }
+
 
 export interface ErrorResponse {
   errorCode: string;

--- a/Loopy-fe/src/apis/axios.ts
+++ b/Loopy-fe/src/apis/axios.ts
@@ -33,13 +33,8 @@ axiosInstance.interceptors.response.use(
   (response) => response,
   (error) => {
     const status = error.response?.status;
-    const message = error.response?.data?.message;
 
-    if (
-      status === 401 &&
-      message === 'The API key provided was invalid or missing.'
-    ) {
-      console.error('로그인이 만료되었습니다. 다시 로그인해주세요.');
+    if (status === 401) {
       Storage.clearStorage();
       window.location.href = '/';
     }

--- a/Loopy-fe/src/pages/auth/VerifyPage.tsx
+++ b/Loopy-fe/src/pages/auth/VerifyPage.tsx
@@ -6,6 +6,7 @@ import { useSavePhone } from "../../hooks/mutation/verify/useSavePhone";
 import { useKeyboardOpen } from "../../hooks/useKeyboardOpen";
 import { useQueryClient } from "@tanstack/react-query";
 import { getIsDummyPhone } from "../../apis/auth/phoneCheck/api";
+import Storage from "../../utils/storage";
 
 const VerifyPage = () => {
   const navigate = useNavigate();
@@ -37,8 +38,13 @@ const VerifyPage = () => {
   const handleSavePhone = async () => {
     try {
       const normalizedPhone = normalizePhone(phoneNumber);
+      const res = await savePhone({ phoneNumber: normalizedPhone });
 
-      await savePhone({ phoneNumber: normalizedPhone });
+      if (res.token) {
+        Storage.setAccessToken(res.token);
+      }
+
+      await queryClient.invalidateQueries();
 
       const result = await queryClient.fetchQuery({
         queryKey: ["isDummyPhone"],


### PR DESCRIPTION
## 📌 변경사항
- 카카오 소셜 로그인 이후 **전화번호 저장 및 계정 병합 흐름**을 구현했습니다.
- 전화번호가 기존 계정에 존재할 경우, **서버 응답의 신규 JWT(token)를 즉시 반영**하여
  병합된 계정 기준으로 인증 상태가 전환되도록 처리했습니다.

## ℹ️ 관련 이슈
- closes #475 

## ✅ 작업 내용 체크리스트
- [X] 전화번호 저장 API(PATCH `/api/v1/users/me/save-phone`) 연동
- [X] 계정 병합 발생 시 응답 token으로 accessToken 교체
- [X] 병합 가능성에 대비한 react-query 서버 상태 invalidate 처리
- [X] axios interceptor에서 요청 시점마다 최신 토큰 참조 구조 확인

## 📷 스크린샷 or 영상 (선택)

## 🧪 테스트 방법 (선택)
1. 카카오 신규 계정으로 로그인 후 전화번호 입력 → 정상 저장 확인
2. 기존 계정에 이미 존재하는 전화번호 입력 → 계정 병합 및 JWT 재발급 확인
3. 병합 이후 추가 API 호출 시, 새 토큰으로 정상 인증되는지 확인
