### PR TITLE
[Fix/#477] 마커 포커싱 문제 해결

### DIFF
--- a/Loopy-fe/src/pages/User/Map/index.tsx
+++ b/Loopy-fe/src/pages/User/Map/index.tsx
@@ -40,6 +40,7 @@ type SelectedCafe = {
 
 interface LocationState {
   focusCafeId?: number;
+  focusCoord?: { lat: number; lng: number }; 
   listParams?: { x: number; y: number; zoom: number };
   detailById?: Record<number, MapCafeDetail>; 
   userCoord?: { x: number; y: number };
@@ -76,11 +77,12 @@ const MapPage = () => {
   const didFocusOnceRef = useRef(false);
 
   useEffect(() => {
-    if (state?.focusCafeId != null) {
-      pendingFocusIdRef.current = state.focusCafeId;
+    const id = (location.state as LocationState | undefined)?.focusCafeId;
+    if (id != null) {
+      pendingFocusIdRef.current = id;
       didFocusOnceRef.current = false;
     }
-  }, [state?.focusCafeId]);
+  }, [location.key]);
 
   const detailByIdRef = useRef<Record<number, MapCafeDetail> | undefined>(state?.detailById);
   useEffect(() => {
@@ -225,9 +227,25 @@ const MapPage = () => {
     };
   }, []); 
 
+  useEffect(() => {
+    const map: any = (mapRef.current as any)?.__map;
+    const focusCoord = (location.state as LocationState | undefined)?.focusCoord;
+
+    if (!map || !mapReady || !focusCoord) return;
+
+    map.setLevel(4);
+    map.setCenter(new window.kakao.maps.LatLng(focusCoord.lat, focusCoord.lng));
+
+    setView({ center: { lat: focusCoord.lat, lng: focusCoord.lng }, zoom: 4 });
+  }, [mapReady, location.key, setView]);
+
   // 리스트에서 위치 설정 후 돌아오면 1회 리센터
   useEffect(() => {
     const map: any = (mapRef.current as any)?.__map;
+    const focusCoord = (location.state as LocationState | undefined)?.focusCoord;
+
+    // 카페 클릭 진입이면 selected 리센터는 하지 않음
+    if (focusCoord) return;
     if (!map || !selected) return;
     if (shouldApplyOnMap) {
       map.setCenter(new window.kakao.maps.LatLng(selected.lat, selected.lng));
@@ -410,22 +428,17 @@ const MapPage = () => {
       }
     });
 
-    if (focusCafeId && !didFocusOnceRef.current) {
-      const marker = markersRef.current.get(focusCafeId);
+    const pendingId = pendingFocusIdRef.current;
 
-      console.log('[FOCUS CHECK]', {
-        focusId: focusCafeId,
-        markerExists: !!marker,
-        allMarkerIds: Array.from(markersRef.current.keys()),
-        cafeIds: cafes.map((c) => c.id),
-      });
+    if (pendingId != null && !didFocusOnceRef.current) {
+      const marker = markersRef.current.get(pendingId);
 
       if (marker) {
         focusMarker(marker);
         if (map.getLevel() !== 4) map.setLevel(4);
         map.panTo(marker.getPosition());
 
-        const c = cafes.find(v => v.id === focusCafeId);
+        const c = cafes.find(v => v.id === pendingId);
         if (c) {
           const center = map.getCenter();
           const meters = typeof c.distance === 'number'
@@ -449,14 +462,10 @@ const MapPage = () => {
                   : Array.isArray(c.bookmarkedBy) && c.bookmarkedBy.length > 0,
             },
           });
-          console.log('[Click] 전달하는 detail:', {
-            id: c.id,
-            isBookmarked: c.isBookmarked,
-            name: c.name,
-          });
         }
 
         didFocusOnceRef.current = true;
+        pendingFocusIdRef.current = null; 
       }
     }
   }, [mapData, focusCafeId, state?.focusCafeId]);

--- a/Loopy-fe/src/pages/User/Search/index.tsx
+++ b/Loopy-fe/src/pages/User/Search/index.tsx
@@ -235,7 +235,12 @@ const SearchPage = () => {
                             state: {
                               detailById,
                               focusCafeId: cafe.id,
-                              userCoord: { x: cafe.longitude, y: cafe.latitude },
+                              // 지도 처음 열릴 때
+                              focusCoord: { lat: cafe.latitude, lng: cafe.longitude },
+                              // userCoord는 진짜 유저/선택 위치(검색 기준) 좌표로
+                              userCoord: { x: baseX, y: baseY },
+                              // 있으면 더 안정적: 지도 조회 기준도 같이
+                              listParams: mapQuerySnapshot,
                             },
                           })
                         }


### PR DESCRIPTION
## 📌 변경사항
- Search → Map 재진입(같은 카페 클릭 포함) 시 state 기반 focusCoord로 지도 중심을 강제 설정하고, 포커스 트리거를 location.key + pending 큐 방식으로 안정화

## ℹ️ 관련 이슈
- closes #477 

## ✅ 작업 내용 체크리스트
- [x] `LocationState` 타입에 `focusCoord?: { lat: number; lng: number }` 추가
- [x] `state?.focusCafeId` 의존하던 리셋 로직을 `location.key` 기반으로 변경
> `pendingFocusIdRef.current = id`
> `didFocusOnceRef.current = false`
- [x] 마커 생성/갱신 useEffect 안에서 포커싱 로직을 `focusCafeId`가 아니라 `pendingFocusIdRef.current`(pendingId) 로 수행하도록 변경
- [x] 카페 클릭 진입 시 지도 초기 위치 강제 리센터 useEffect 추가
- [x] `shouldApplyOnMap` 리센터 로직이 카페 리센터를 덮어쓰면 방지 처리
- [x] SearchPage에서 카페 카드 클릭 `navigate('/map', { state: ... })` 에서 state 수정

