### PR TITLE
[Refactor/#480] PWA 캐시 자동 갱신

### DIFF
--- a/Loopy-fe/vite.config.ts
+++ b/Loopy-fe/vite.config.ts
@@ -4,13 +4,15 @@ import svgr from 'vite-plugin-svgr'
 import { VitePWA } from 'vite-plugin-pwa'
 import tailwindcss from '@tailwindcss/vite'
 
-// https://vite.dev/config/
+const BUILD_VERSION = Date.now();
+const withVersion = (name: string) => `${name}-v${BUILD_VERSION}`;
+
 export default defineConfig({
   define: {
     global: 'globalThis',
   },
   plugins: [
-    react(), 
+    react(),
     tailwindcss(),
     svgr(),
     VitePWA({
@@ -19,57 +21,34 @@ export default defineConfig({
         short_name: "LOOPy",
         name: "LOOPy | 고객의 루틴에 나의 커피를 더하다",
         icons: [
-          {
-            src: "/icon.png",
-            sizes: "64x64",
-            type: "image/png",
-            purpose: "any maskable",
-          },
-          {
-            src: "/icon2.png",
-            type: "image/png",
-            sizes: "192x192",
-            purpose: "any maskable",
-          },
-          {
-            src: "/icon3.png",
-            type: "image/png",
-            sizes: "512x512",
-            purpose: "any maskable",
-          }
+          { src: "/icon.png", sizes: "64x64", type: "image/png", purpose: "any maskable" },
+          { src: "/icon2.png", sizes: "192x192", type: "image/png", purpose: "any maskable" },
+          { src: "/icon3.png", sizes: "512x512", type: "image/png", purpose: "any maskable" },
         ],
         start_url: ".",
         display: "standalone",
-        theme_color: "#6970F3",        
-        background_color: "#555BC5"
+        theme_color: "#6970F3",
+        background_color: "#555BC5",
       },
       workbox: {
         maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
-        
         globPatterns: [
           'index.html',
           'manifest.webmanifest',
-          '**/*.{js,css,ico,png,svg,jpg,jpeg,webp}'
+          '**/*.{js,css,ico,png,svg,jpg,jpeg,webp}',
         ],
         runtimeCaching: [
           {
-            // API 요청은 항상 네트워크
+            // API 요청은 항상 네트워크 (캐시 안 씀)
             urlPattern: /^https:\/\/api\..*$/i,
             handler: 'NetworkOnly',
-            options: {
-              cacheName: 'loopy-pwa-cache-v1',
-              expiration: {
-                maxEntries: 100,
-                maxAgeSeconds: 24 * 60 * 60,
-              },
-            },
           },
           {
-            // 외부 이미지 요청은 캐시
-            urlPattern: /^https:\/\/.*\.(?:png|jpg|jpeg|webp|gif|svg)$/,
+            // 외부 이미지 캐시 (버전 포함)
+            urlPattern: /^https:\/\/.*\.(?:png|jpg|jpeg|webp|gif|svg)$/i,
             handler: 'NetworkFirst',
             options: {
-              cacheName: 'external-images',
+              cacheName: withVersion('external-images'),
               expiration: {
                 maxEntries: 50,
                 maxAgeSeconds: 7 * 24 * 60 * 60,
@@ -82,19 +61,13 @@ export default defineConfig({
           {
             urlPattern: /^https:\/\/www\.google\.com\/recaptcha\/.*$/i,
             handler: 'NetworkOnly',
-            options: {
-              cacheName: 'google-recaptcha',
-            },
           },
           {
             urlPattern: /^https:\/\/www\.gstatic\.com\/recaptcha\/.*$/i,
             handler: 'NetworkOnly',
-            options: {
-              cacheName: 'gstatic-recaptcha',
-            },
           },
         ],
-      }
+      },
     }),
   ],
 });


### PR DESCRIPTION
## 📌 변경사항
- PWA 배포 후에도 설치된 앱에서 이전 캐시가 유지되던 문제를 해결했습니다.
- Workbox runtimeCaching의 cacheName을 빌드 시점 기반으로 버저닝하여,
  캐시 삭제 없이도 머지·재배포 시 최신 버전이 자동 반영되도록 개선했습니다.

## ℹ️ 관련 이슈
- closes #480

## ✅ 작업 내용 체크리스트
- [x] PWA 캐시 정책 개선
- [x] Workbox runtimeCaching cacheName 버저닝 적용
- [x] 빌드 시점(Date.now()) 기반 캐시 버전 도입
- [x] 캐시 삭제 / PWA 재설치 없이 업데이트 가능하도록 수정

## 📷 스크린샷 or 영상 (선택)

## 🧪 테스트 방법 (선택)
1. 기존 PWA가 설치된 상태에서 앱 실행
2. 코드 머지 후 재배포 진행
3. PWA 앱 종료 후 다시 실행
4. 캐시 삭제나 재설치 없이 최신 코드가 정상 반영되는지 확인
